### PR TITLE
chore(): use 3 components version number

### DIFF
--- a/krank.cabal
+++ b/krank.cabal
@@ -3,7 +3,7 @@ cabal-version:       >=1.10
 -- For further documentation, see http://haskell.org/cabal/users-guide/
 
 name:                krank
-version:             0.1.0.0
+version:             0.1.0
 -- synopsis:
 -- description:
 -- bug-reports:


### PR DESCRIPTION
Don't know what you think about this one, but I'm yet to understand how to manage the 4 components version number. I usually only use 3