### PR TITLE
feat: find github issues in file

### DIFF
--- a/krank.cabal
+++ b/krank.cabal
@@ -19,6 +19,7 @@ extra-source-files:  CHANGELOG.md, README.md
 
 library
   exposed-modules:     Krank
+                       Krank.Checkers.Common
                        Krank.Checkers.IssueTracker
                        Krank.Formatter
                        Krank.Types

--- a/krank.cabal
+++ b/krank.cabal
@@ -39,6 +39,7 @@ test-suite krank-test
   build-tools:
   build-depends:       base
                        , hspec >= 2.7 && < 2.8
+                       , PyF >= 0.8.1.0 && < 0.9
                        , regex-applicative >= 0.3 && < 0.4
                        , krank
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N

--- a/src/Krank/Checkers/Common.hs
+++ b/src/Krank/Checkers/Common.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE ApplicativeDo #-}
+
+module Krank.Checkers.Common (
+  multiple
+  ) where
+
+import Text.Regex.Applicative (RE(), anySym, few, many)
+
+-- | Tries to match a RE multiply times, with anything in between the multiple possible matches
+multiple :: RE a b
+         -> RE a [b]
+multiple re = many $ do
+  few anySym
+  match <- re
+  few anySym
+  pure match

--- a/src/Krank/Checkers/IssueTracker.hs
+++ b/src/Krank/Checkers/IssueTracker.hs
@@ -22,7 +22,7 @@ githubRE = do
   few (psym ('/' /=))
   "/"
   "issues/"
-  issueNum <- few (psym isDigit)
+  issueNum <- some (psym isDigit)
   optional "/"
   return $ read issueNum
 

--- a/src/Krank/Checkers/IssueTracker.hs
+++ b/src/Krank/Checkers/IssueTracker.hs
@@ -25,8 +25,6 @@ githubRE = do
   "/"
   "issues/"
   issueNum <- some (psym isDigit)
-  optional "/"
-  " " <|> "\t" <|> "\n"
   return $ read issueNum
 
 check :: FilePath

--- a/src/Krank/Checkers/IssueTracker.hs
+++ b/src/Krank/Checkers/IssueTracker.hs
@@ -8,7 +8,9 @@ module Krank.Checkers.IssueTracker (
 
 import Control.Applicative ((*>), optional)
 import Data.Char (isDigit)
-import Text.Regex.Applicative ((=~), RE(), anySym, few, psym)
+import Data.Maybe (fromMaybe)
+import System.IO (readFile)
+import Text.Regex.Applicative ((<|>), (=~), RE(), anySym, few, many, psym, some)
 
 import Krank.Types
 
@@ -28,5 +30,9 @@ githubRE = do
   return $ read issueNum
 
 check :: FilePath
-      -> [Violation]
-check file = []
+      -> IO [Int]
+check file = do
+  content <- readFile file
+  print content
+  let mMatches = content =~ many ((few anySym) *> githubRE <* (few anySym))
+  pure $ fromMaybe [] mMatches

--- a/src/Krank/Checkers/IssueTracker.hs
+++ b/src/Krank/Checkers/IssueTracker.hs
@@ -5,13 +5,15 @@ module Krank.Checkers.IssueTracker (
   GitIssue(..)
   , check
   , githubRE
+  , gitlabRE
+  , gitRepoRE
   ) where
 
 import Control.Applicative ((*>), optional)
 import Data.Char (isDigit)
 import Data.Maybe (fromMaybe)
 import System.IO (readFile)
-import Text.Regex.Applicative ((=~), RE(), anySym, few, many, psym, some)
+import Text.Regex.Applicative ((=~), RE(), anySym, few, many, psym, some, string)
 
 import Krank.Types
 
@@ -22,10 +24,18 @@ data GitIssue = GitIssue {
 } deriving (Eq, Show)
 
 githubRE :: RE Char GitIssue
-githubRE = do
+githubRE = gitRepoRE "github.com"
+
+gitlabRE :: RE Char GitIssue
+gitlabRE = gitRepoRE "gitlab.com"
+
+gitRepoRE :: String
+          -> RE Char GitIssue
+gitRepoRE host = do
   optional ("http" *> optional "s" *> "://")
   optional "www."
-  "github.com/"
+  string host
+  "/"
   repoOwner <- few (psym ('/' /=))
   "/"
   repoName <- few (psym ('/' /=))

--- a/src/Krank/Checkers/IssueTracker.hs
+++ b/src/Krank/Checkers/IssueTracker.hs
@@ -16,6 +16,7 @@ import Data.Maybe (fromMaybe)
 import System.IO (readFile)
 import Text.Regex.Applicative ((=~), RE(), anySym, few, many, psym, some, string)
 
+import Krank.Checkers.Common
 import Krank.Types
 
 data GitIssue = GitIssue {
@@ -52,7 +53,7 @@ extractIssues toCheck =
   concat matches
     where
       patterns = [githubRE, gitlabRE]
-      mMatches = (\x -> toCheck =~ many ((few anySym) *> x <* (few anySym))) <$> patterns
+      mMatches = (=~) toCheck . multiple <$> patterns
       matches = fromMaybe [] <$> mMatches
 
 check :: FilePath

--- a/src/Krank/Checkers/IssueTracker.hs
+++ b/src/Krank/Checkers/IssueTracker.hs
@@ -24,6 +24,7 @@ githubRE = do
   "issues/"
   issueNum <- some (psym isDigit)
   optional "/"
+  " " <|> "\t" <|> "\n"
   return $ read issueNum
 
 check :: FilePath

--- a/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
+++ b/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
@@ -9,38 +9,38 @@ import Text.Regex.Applicative ((=~))
 import Krank.Checkers.IssueTracker
 
 spec :: Spec
-spec = do
-  context "Test.Krank.Checkers.specIssueTracker" $ do
+spec =
+  context "Test.Krank.Checkers.specIssueTracker" $
     describe "#githubRE" $ do
-      it "handles full https url" $ do
-        "https://github.com/guibou/krank/issues/1" =~ githubRE `shouldBe` Just 1
+      it "handles full https url" $
+        "https://github.com/guibou/krank/issues/1" =~ githubRE `shouldBe` (Just $ GitIssue "guibou" "krank" 1)
 
-      it "handles full http url" $ do
-        "http://github.com/guibou/krank/issues/1" =~ githubRE `shouldBe` Just 1
+      it "handles full http url" $
+        "http://github.com/guibou/krank/issues/1" =~ githubRE `shouldBe` (Just $ GitIssue "guibou" "krank" 1)
 
-      it "handles short url - no protocol" $ do
-        "github.com/guibou/krank/issues/1" =~ githubRE `shouldBe` Just 1
+      it "handles short url - no protocol" $
+        "github.com/guibou/krank/issues/1" =~ githubRE `shouldBe` (Just $ GitIssue "guibou" "krank" 1)
 
-      it "accepts www in url" $ do
-        "https://www.github.com/guibou/krank/issues/1" =~ githubRE `shouldBe` Just 1
+      it "accepts www in url" $
+        "https://www.github.com/guibou/krank/issues/1" =~ githubRE `shouldBe` (Just $ GitIssue "guibou" "krank" 1)
 
-      it "accepts www in url - no protocol" $ do
-        "www.github.com/guibou/krank/issues/1" =~ githubRE `shouldBe` Just 1
+      it "accepts www in url - no protocol" $
+        "www.github.com/guibou/krank/issues/1" =~ githubRE `shouldBe` (Just $ GitIssue "guibou" "krank" 1)
 
-      it "fails if the issue number is not an int" $ do
+      it "fails if the issue number is not an int" $
         "github.com/guibou/krank/issues/foo" =~ githubRE `shouldBe` Nothing
 
-      it "fails if there are too many components in the path" $ do
+      it "fails if there are too many components in the path" $
         "github.com/guibou/krank/should_not_be_here/issues/1" =~ githubRE `shouldBe` Nothing
 
-      it "fails if github not in path" $ do
+      it "fails if github not in path" $
         "google.com/guibou/krank/issues/1" =~ githubRE `shouldBe` Nothing
 
-      it "fails if not a github issue" $ do
+      it "fails if not a github issue" $
         "github.com/guibou/krank/branches/1" =~ githubRE `shouldBe` Nothing
 
-      it "fails on partial match" $ do
+      it "fails on partial match" $
         "github.com/guibou/krank/" =~ githubRE `shouldBe` Nothing
 
-      it "fails on partial match (just missing the issue number)" $ do
+      it "fails on partial match (just missing the issue number)" $
         "github.com/guibou/krank/issues/" =~ githubRE `shouldBe` Nothing

--- a/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
+++ b/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
@@ -63,12 +63,24 @@ spec =
         let match = "github.com/guibou/krank/issues/" =~ gitRepoRE "github.com"
         match `shouldBe` Nothing
 
-    describe "#gitlabRE" $ do
+    describe "#gitlabRE" $
       it "handles full https url" $ do
         let match = "https://gitlab.com/gitlab-org/gitlab-foss/issues/67390" =~ gitlabRE
         match `shouldBe` (Just $ GitIssue "gitlab-org" "gitlab-foss" 67390)
 
-    describe "#githubRE" $ do
+    describe "#githubRE" $
       it "handles full https url" $ do
         let match = "https://github.com/guibou/krank/issues/2" =~ githubRE
         match `shouldBe` (Just $ GitIssue "guibou" "krank" 2)
+
+    describe "#extractIssues" $
+      it "handles both github and gitlab" $ do
+        let match = extractIssues [fmt|https://github.com/guibou/krank/issues/2
+        some text
+        https://gitlab.com/gitlab-org/gitlab-foss/issues/67390
+        and more github https://github.com/guibou/krank/issues/1
+        |]
+        match `shouldMatchList` [
+          GitIssue "guibou" "krank" 2
+          , GitIssue "gitlab-org" "gitlab-foss" 67390
+          , GitIssue "guibou" "krank" 1 ]

--- a/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
+++ b/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
@@ -13,34 +13,34 @@ spec = do
   context "Test.Krank.Checkers.specIssueTracker" $ do
     describe "#githubRE" $ do
       it "handles full https url" $ do
-        "https://github.com/guibou/krank/issues/1" =~ githubRE `shouldBe` Just 1
+        "https://github.com/guibou/krank/issues/1\n" =~ githubRE `shouldBe` Just 1
 
       it "handles full http url" $ do
-        "http://github.com/guibou/krank/issues/1" =~ githubRE `shouldBe` Just 1
+        "http://github.com/guibou/krank/issues/1\n" =~ githubRE `shouldBe` Just 1
 
       it "handles short url - no protocol" $ do
-        "github.com/guibou/krank/issues/1" =~ githubRE `shouldBe` Just 1
+        "github.com/guibou/krank/issues/1\n" =~ githubRE `shouldBe` Just 1
 
       it "accepts www in url" $ do
-        "https://www.github.com/guibou/krank/issues/1" =~ githubRE `shouldBe` Just 1
+        "https://www.github.com/guibou/krank/issues/1\n" =~ githubRE `shouldBe` Just 1
 
       it "accepts www in url - no protocol" $ do
-        "www.github.com/guibou/krank/issues/1" =~ githubRE `shouldBe` Just 1
+        "www.github.com/guibou/krank/issues/1\n" =~ githubRE `shouldBe` Just 1
 
       it "accepts trailing slash" $ do
-        "github.com/guibou/krank/issues/1/" =~ githubRE `shouldBe` Just 1
+        "github.com/guibou/krank/issues/1/\n" =~ githubRE `shouldBe` Just 1
 
       it "fails if the issue number is not an int" $ do
-        "github.com/guibou/krank/issues/foo" =~ githubRE `shouldBe` Nothing
+        "github.com/guibou/krank/issues/foo\n" =~ githubRE `shouldBe` Nothing
 
       it "fails if there are too many components in the path" $ do
-        "github.com/guibou/krank/should_not_be_here/issues/1" =~ githubRE `shouldBe` Nothing
+        "github.com/guibou/krank/should_not_be_here/issues/1\n" =~ githubRE `shouldBe` Nothing
 
       it "fails if github not in path" $ do
-        "google.com/guibou/krank/issues/1" =~ githubRE `shouldBe` Nothing
+        "google.com/guibou/krank/issues/1\n" =~ githubRE `shouldBe` Nothing
 
       it "fails if not a github issue" $ do
-        "github.com/guibou/krank/branches/1" =~ githubRE `shouldBe` Nothing
+        "github.com/guibou/krank/branches/1\n" =~ githubRE `shouldBe` Nothing
 
       it "fails on partial match" $ do
         "github.com/guibou/krank/\n" =~ githubRE `shouldBe` Nothing

--- a/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
+++ b/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
@@ -13,37 +13,34 @@ spec = do
   context "Test.Krank.Checkers.specIssueTracker" $ do
     describe "#githubRE" $ do
       it "handles full https url" $ do
-        "https://github.com/guibou/krank/issues/1\n" =~ githubRE `shouldBe` Just 1
+        "https://github.com/guibou/krank/issues/1" =~ githubRE `shouldBe` Just 1
 
       it "handles full http url" $ do
-        "http://github.com/guibou/krank/issues/1\n" =~ githubRE `shouldBe` Just 1
+        "http://github.com/guibou/krank/issues/1" =~ githubRE `shouldBe` Just 1
 
       it "handles short url - no protocol" $ do
-        "github.com/guibou/krank/issues/1\n" =~ githubRE `shouldBe` Just 1
+        "github.com/guibou/krank/issues/1" =~ githubRE `shouldBe` Just 1
 
       it "accepts www in url" $ do
-        "https://www.github.com/guibou/krank/issues/1\n" =~ githubRE `shouldBe` Just 1
+        "https://www.github.com/guibou/krank/issues/1" =~ githubRE `shouldBe` Just 1
 
       it "accepts www in url - no protocol" $ do
-        "www.github.com/guibou/krank/issues/1\n" =~ githubRE `shouldBe` Just 1
-
-      it "accepts trailing slash" $ do
-        "github.com/guibou/krank/issues/1/\n" =~ githubRE `shouldBe` Just 1
+        "www.github.com/guibou/krank/issues/1" =~ githubRE `shouldBe` Just 1
 
       it "fails if the issue number is not an int" $ do
-        "github.com/guibou/krank/issues/foo\n" =~ githubRE `shouldBe` Nothing
+        "github.com/guibou/krank/issues/foo" =~ githubRE `shouldBe` Nothing
 
       it "fails if there are too many components in the path" $ do
-        "github.com/guibou/krank/should_not_be_here/issues/1\n" =~ githubRE `shouldBe` Nothing
+        "github.com/guibou/krank/should_not_be_here/issues/1" =~ githubRE `shouldBe` Nothing
 
       it "fails if github not in path" $ do
-        "google.com/guibou/krank/issues/1\n" =~ githubRE `shouldBe` Nothing
+        "google.com/guibou/krank/issues/1" =~ githubRE `shouldBe` Nothing
 
       it "fails if not a github issue" $ do
-        "github.com/guibou/krank/branches/1\n" =~ githubRE `shouldBe` Nothing
+        "github.com/guibou/krank/branches/1" =~ githubRE `shouldBe` Nothing
 
       it "fails on partial match" $ do
-        "github.com/guibou/krank/\n" =~ githubRE `shouldBe` Nothing
+        "github.com/guibou/krank/" =~ githubRE `shouldBe` Nothing
 
       it "fails on partial match (just missing the issue number)" $ do
-        "github.com/guibou/krank/issues/\n" =~ githubRE `shouldBe` Nothing
+        "github.com/guibou/krank/issues/" =~ githubRE `shouldBe` Nothing

--- a/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
+++ b/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
@@ -39,5 +39,11 @@ spec = do
       it "fails if github not in path" $ do
         "google.com/guibou/krank/issues/1" =~ githubRE `shouldBe` Nothing
 
-      it "fails if github not in path" $ do
+      it "fails if not a github issue" $ do
         "github.com/guibou/krank/branches/1" =~ githubRE `shouldBe` Nothing
+
+      it "fails on partial match" $ do
+        "github.com/guibou/krank/\n" =~ githubRE `shouldBe` Nothing
+
+      it "fails on partial match (just missing the issue number)" $ do
+        "github.com/guibou/krank/issues/\n" =~ githubRE `shouldBe` Nothing

--- a/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
+++ b/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
@@ -1,46 +1,74 @@
+{-# LANGUAGE QuasiQuotes #-}
+
 module Test.Krank.Checkers.IssueTrackerSpec (
   spec
   ) where
 
+import PyF (fmt)
 import Test.Hspec
-
 import Text.Regex.Applicative ((=~))
 
 import Krank.Checkers.IssueTracker
 
 spec :: Spec
 spec =
-  context "Test.Krank.Checkers.specIssueTracker" $
+  context "Test.Krank.Checkers.specIssueTracker" $ do
+    describe "#gitRepoRE" $ do
+      it "handles full https url" $ do
+        let match = "https://github.com/guibou/krank/issues/1" =~ gitRepoRE "github.com"
+        match `shouldBe` (Just $ GitIssue "guibou" "krank" 1)
+
+      it "handles full http url" $ do
+        let match = "http://github.com/guibou/krank/issues/1" =~ gitRepoRE "github.com"
+        match `shouldBe` (Just $ GitIssue "guibou" "krank" 1)
+
+      it "handles short url - no protocol" $ do
+        let match = "github.com/guibou/krank/issues/1" =~ gitRepoRE "github.com"
+        match `shouldBe` (Just $ GitIssue "guibou" "krank" 1)
+
+      it "accepts www in url" $ do
+        let match = "https://www.github.com/guibou/krank/issues/1" =~ gitRepoRE "github.com"
+        match `shouldBe` (Just $ GitIssue "guibou" "krank" 1)
+
+      it "accepts www in url - no protocol" $ do
+        let match = "www.github.com/guibou/krank/issues/1" =~ gitRepoRE "github.com"
+        match `shouldBe` (Just $ GitIssue "guibou" "krank" 1)
+
+      it "uses its parameter to match the host" $ do
+        let host = "foobar.baz"
+        let match = [fmt|https://www.{host}/guibou/krank/issues/1|] =~ gitRepoRE host
+        match `shouldBe` (Just $ GitIssue "guibou" "krank" 1)
+
+      it "fails if the issue number is not an int" $ do
+        let match = "github.com/guibou/krank/issues/foo" =~ gitRepoRE "github.com"
+        match `shouldBe` Nothing
+
+      it "fails if there are too many components in the path" $ do
+        let match = "github.com/guibou/krank/should_not_be_here/issues/1" =~ gitRepoRE "github.com"
+        match `shouldBe` Nothing
+
+      it "fails if github not in path" $ do
+        let match = "google.com/guibou/krank/issues/1" =~ gitRepoRE "github.com"
+        match `shouldBe` Nothing
+
+      it "fails if not a github issue" $ do
+        let match = "github.com/guibou/krank/branches/1" =~ gitRepoRE "github.com"
+        match `shouldBe` Nothing
+
+      it "fails on partial match" $ do
+        let match = "github.com/guibou/krank/" =~ gitRepoRE "github.com"
+        match `shouldBe` Nothing
+
+      it "fails on partial match (just missing the issue number)" $ do
+        let match = "github.com/guibou/krank/issues/" =~ gitRepoRE "github.com"
+        match `shouldBe` Nothing
+
+    describe "#gitlabRE" $ do
+      it "handles full https url" $ do
+        let match = "https://gitlab.com/gitlab-org/gitlab-foss/issues/67390" =~ gitlabRE
+        match `shouldBe` (Just $ GitIssue "gitlab-org" "gitlab-foss" 67390)
+
     describe "#githubRE" $ do
-      it "handles full https url" $
-        "https://github.com/guibou/krank/issues/1" =~ githubRE `shouldBe` (Just $ GitIssue "guibou" "krank" 1)
-
-      it "handles full http url" $
-        "http://github.com/guibou/krank/issues/1" =~ githubRE `shouldBe` (Just $ GitIssue "guibou" "krank" 1)
-
-      it "handles short url - no protocol" $
-        "github.com/guibou/krank/issues/1" =~ githubRE `shouldBe` (Just $ GitIssue "guibou" "krank" 1)
-
-      it "accepts www in url" $
-        "https://www.github.com/guibou/krank/issues/1" =~ githubRE `shouldBe` (Just $ GitIssue "guibou" "krank" 1)
-
-      it "accepts www in url - no protocol" $
-        "www.github.com/guibou/krank/issues/1" =~ githubRE `shouldBe` (Just $ GitIssue "guibou" "krank" 1)
-
-      it "fails if the issue number is not an int" $
-        "github.com/guibou/krank/issues/foo" =~ githubRE `shouldBe` Nothing
-
-      it "fails if there are too many components in the path" $
-        "github.com/guibou/krank/should_not_be_here/issues/1" =~ githubRE `shouldBe` Nothing
-
-      it "fails if github not in path" $
-        "google.com/guibou/krank/issues/1" =~ githubRE `shouldBe` Nothing
-
-      it "fails if not a github issue" $
-        "github.com/guibou/krank/branches/1" =~ githubRE `shouldBe` Nothing
-
-      it "fails on partial match" $
-        "github.com/guibou/krank/" =~ githubRE `shouldBe` Nothing
-
-      it "fails on partial match (just missing the issue number)" $
-        "github.com/guibou/krank/issues/" =~ githubRE `shouldBe` Nothing
+      it "handles full https url" $ do
+        let match = "https://github.com/guibou/krank/issues/2" =~ githubRE
+        match `shouldBe` (Just $ GitIssue "guibou" "krank" 2)


### PR DESCRIPTION
Not really ready but submitting the start for review.
Applies the RE, multiple times, to a file's content.

* fixes a bug where it would match even if the issue number was missing
* In the future, we'll most likely want to make the "multiple application of a RE" something generic
* I think I want the reading of the file to be elsewhere and then we apply all the checkers. I think we can assume that one single file of code "fits" in memory.
* I need to return more than just the issue number (owner + repo, maybe the full string matched)
* more tests