### PR TITLE
1 get GitHub issue status

### DIFF
--- a/krank.cabal
+++ b/krank.cabal
@@ -25,8 +25,10 @@ library
                        Krank.Types
 
   build-depends:       base >= 4.9 && < 5.0
+                       , aeson >= 1.4.4 && < 1.5
                        , PyF >= 0.8.1.0 && < 0.9
                        , regex-applicative >= 0.3 && < 0.4
+                       , req >= 2.1.0 && < 2.2
                        , text >= 1.2.3 && < 1.3
   hs-source-dirs:      src
   ghc-options: -Wall

--- a/src/Krank/Checkers/IssueTracker.hs
+++ b/src/Krank/Checkers/IssueTracker.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Krank.Checkers.IssueTracker (
@@ -8,35 +9,58 @@ module Krank.Checkers.IssueTracker (
   , githubRE
   , gitlabRE
   , gitRepoRE
+
   ) where
 
 import Control.Applicative ((*>), optional)
+import Data.Aeson (Value, (.:))
+import qualified Data.Aeson.Types as AesonT
 import Data.Char (isDigit)
 import Data.Maybe (fromMaybe)
+import Data.Text (Text, pack)
+import qualified Network.HTTP.Req as Req
 import System.IO (readFile)
-import Text.Regex.Applicative ((=~), RE(), anySym, few, many, psym, some, string)
+import Text.Regex.Applicative ((=~), RE(), few, psym, some, string)
 
 import Krank.Checkers.Common
-import Krank.Types
+
+data GitServer = Github | Gitlab deriving (Eq, Show)
+
+data IssueStatus = Open | Closed deriving (Eq, Show)
+-- TODO - can it be done with readPrec?
+instance Read IssueStatus where
+  readsPrec _ "closed" = [(Closed, "")]
+  readsPrec _ _ = [(Open, "")]
 
 data GitIssue = GitIssue {
-  owner :: String,
-  repo :: String,
+  server :: GitServer,
+  owner :: Text,
+  repo :: Text,
   issueNum :: Int
 } deriving (Eq, Show)
 
+data GitIssueWithStatus = GitIssueWithStatus {
+  gitIssue :: GitIssue,
+  issueStatus :: IssueStatus
+} deriving (Eq, Show)
+
+serverDomain :: GitServer
+             -> String
+serverDomain Github = "github.com"
+serverDomain Gitlab = "gitlab.com"
+
 githubRE :: RE Char GitIssue
-githubRE = gitRepoRE "github.com"
+githubRE = gitRepoRE Github
 
 gitlabRE :: RE Char GitIssue
-gitlabRE = gitRepoRE "gitlab.com"
+gitlabRE = gitRepoRE Gitlab
 
-gitRepoRE :: String
+gitRepoRE :: GitServer
           -> RE Char GitIssue
-gitRepoRE host = do
+gitRepoRE gitServer = do
   optional ("http" *> optional "s" *> "://")
   optional "www."
-  string host
+  string (serverDomain gitServer)
   "/"
   repoOwner <- few (psym ('/' /=))
   "/"
@@ -45,7 +69,7 @@ gitRepoRE host = do
   "issues/"
   issueNumStr <- some (psym isDigit)
   -- Note that read is safe because of the regex parsing
-  return $ GitIssue repoOwner repoName (read issueNumStr)
+  return $ GitIssue gitServer (pack repoOwner) (pack repoName) (read issueNumStr)
 
 extractIssues :: String
               -> [GitIssue]
@@ -56,8 +80,37 @@ extractIssues toCheck =
       mMatches = (=~) toCheck . multiple <$> patterns
       matches = fromMaybe [] <$> mMatches
 
+-- Supports only github for the moment
+issueUrl :: GitIssue
+         -> Req.Url 'Req.Https
+issueUrl issue
+  | server issue == Github = Req.https "api.github.com" Req./: "repos" Req./: owner issue Req./: repo issue Req./: "issues" Req./: (pack . show $ issueNum issue)
+  | server issue == Gitlab = Req.https "google.com"
+
+restIssue :: Req.Url 'Req.Https
+            -> IO Value
+restIssue url = Req.runReq Req.defaultHttpConfig $ do
+  r <- Req.req Req.GET url Req.NoReqBody Req.jsonResponse (Req.header "User-Agent" "krank")
+  pure $ Req.responseBody r
+
+getStatus :: Value
+          -> AesonT.Result String
+getStatus (AesonT.Object o) = AesonT.parse (\x -> x .: "state") o
+getStatus _ = AesonT.Error "invalid JSON"
+
+parseStatus :: AesonT.Result String
+            -> Either String IssueStatus
+parseStatus (AesonT.Success status) = Right $ read status
+parseStatus (AesonT.Error err) = Left err
+
 check :: FilePath
-      -> IO [GitIssue]
+      -> IO [Either String GitIssueWithStatus]
 check file = do
   content <- readFile file
-  pure $ extractIssues content
+  let issues = extractIssues content
+  let urls = issueUrl <$> issues
+  statuses <- mapM restIssue urls
+  pure $ zipWith f issues (fmap (parseStatus . getStatus) statuses)
+    where
+      f _ (Left err) = Left err
+      f issue (Right is) = Right $ GitIssueWithStatus issue is

--- a/src/Krank/Checkers/IssueTracker.hs
+++ b/src/Krank/Checkers/IssueTracker.hs
@@ -5,14 +5,12 @@
 
 module Krank.Checkers.IssueTracker (
   GitIssue(..)
+  , GitServer(..)
   , check
   , extractIssues
   , githubRE
   , gitlabRE
   , gitRepoRE
-
-                                   , IssueStatus(..)
-                                   , parseStatus
   ) where
 
 import Control.Applicative ((*>), optional)

--- a/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
+++ b/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 
 module Test.Krank.Checkers.IssueTrackerSpec (
@@ -13,65 +14,60 @@ import Krank.Checkers.IssueTracker
 spec :: Spec
 spec =
   context "Test.Krank.Checkers.specIssueTracker" $ do
-    describe "#gitRepoRE" $ do
+    describe "#githubRE" $ do
       it "handles full https url" $ do
-        let match = "https://github.com/guibou/krank/issues/1" =~ gitRepoRE "github.com"
-        match `shouldBe` (Just $ GitIssue "guibou" "krank" 1)
+        let match = "https://github.com/guibou/krank/issues/1" =~ githubRE
+        match `shouldBe` (Just $ GitIssue Github "guibou" "krank" 1)
 
       it "handles full http url" $ do
-        let match = "http://github.com/guibou/krank/issues/1" =~ gitRepoRE "github.com"
-        match `shouldBe` (Just $ GitIssue "guibou" "krank" 1)
+        let match = "http://github.com/guibou/krank/issues/1" =~ githubRE
+        match `shouldBe` (Just $ GitIssue Github "guibou" "krank" 1)
 
       it "handles short url - no protocol" $ do
-        let match = "github.com/guibou/krank/issues/1" =~ gitRepoRE "github.com"
-        match `shouldBe` (Just $ GitIssue "guibou" "krank" 1)
+        let match = "github.com/guibou/krank/issues/1" =~ githubRE
+        match `shouldBe` (Just $ GitIssue Github "guibou" "krank" 1)
 
       it "accepts www in url" $ do
-        let match = "https://www.github.com/guibou/krank/issues/1" =~ gitRepoRE "github.com"
-        match `shouldBe` (Just $ GitIssue "guibou" "krank" 1)
+        let match = "https://www.github.com/guibou/krank/issues/1" =~ githubRE
+        match `shouldBe` (Just $ GitIssue Github "guibou" "krank" 1)
 
       it "accepts www in url - no protocol" $ do
-        let match = "www.github.com/guibou/krank/issues/1" =~ gitRepoRE "github.com"
-        match `shouldBe` (Just $ GitIssue "guibou" "krank" 1)
-
-      it "uses its parameter to match the host" $ do
-        let host = "foobar.baz"
-        let match = [fmt|https://www.{host}/guibou/krank/issues/1|] =~ gitRepoRE host
-        match `shouldBe` (Just $ GitIssue "guibou" "krank" 1)
+        let match = "www.github.com/guibou/krank/issues/1" =~ githubRE
+        match `shouldBe` (Just $ GitIssue Github "guibou" "krank" 1)
 
       it "fails if the issue number is not an int" $ do
-        let match = "github.com/guibou/krank/issues/foo" =~ gitRepoRE "github.com"
+        let match = "github.com/guibou/krank/issues/foo" =~ githubRE
         match `shouldBe` Nothing
 
       it "fails if there are too many components in the path" $ do
-        let match = "github.com/guibou/krank/should_not_be_here/issues/1" =~ gitRepoRE "github.com"
+        let match = "github.com/guibou/krank/should_not_be_here/issues/1" =~ githubRE
         match `shouldBe` Nothing
 
       it "fails if github not in path" $ do
-        let match = "google.com/guibou/krank/issues/1" =~ gitRepoRE "github.com"
+        let match = "google.com/guibou/krank/issues/1" =~ githubRE
         match `shouldBe` Nothing
 
       it "fails if not a github issue" $ do
-        let match = "github.com/guibou/krank/branches/1" =~ gitRepoRE "github.com"
+        let match = "github.com/guibou/krank/branches/1" =~ githubRE
         match `shouldBe` Nothing
 
       it "fails on partial match" $ do
-        let match = "github.com/guibou/krank/" =~ gitRepoRE "github.com"
+        let match = "github.com/guibou/krank/" =~ githubRE
         match `shouldBe` Nothing
 
       it "fails on partial match (just missing the issue number)" $ do
-        let match = "github.com/guibou/krank/issues/" =~ gitRepoRE "github.com"
+        let match = "github.com/guibou/krank/issues/" =~ githubRE
         match `shouldBe` Nothing
 
     describe "#gitlabRE" $
       it "handles full https url" $ do
         let match = "https://gitlab.com/gitlab-org/gitlab-foss/issues/67390" =~ gitlabRE
-        match `shouldBe` (Just $ GitIssue "gitlab-org" "gitlab-foss" 67390)
+        match `shouldBe` (Just $ GitIssue Gitlab "gitlab-org" "gitlab-foss" 67390)
 
     describe "#githubRE" $
       it "handles full https url" $ do
         let match = "https://github.com/guibou/krank/issues/2" =~ githubRE
-        match `shouldBe` (Just $ GitIssue "guibou" "krank" 2)
+        match `shouldBe` (Just $ GitIssue Github "guibou" "krank" 2)
 
     describe "#extractIssues" $
       it "handles both github and gitlab" $ do
@@ -81,6 +77,6 @@ spec =
         and more github https://github.com/guibou/krank/issues/1
         |]
         match `shouldMatchList` [
-          GitIssue "guibou" "krank" 2
-          , GitIssue "gitlab-org" "gitlab-foss" 67390
-          , GitIssue "guibou" "krank" 1 ]
+          GitIssue Github "guibou" "krank" 2
+          , GitIssue Gitlab "gitlab-org" "gitlab-foss" 67390
+          , GitIssue Github "guibou" "krank" 1 ]


### PR DESCRIPTION
POC code to review

* Do you know how to implement an instance of `Read` with `readPrec` rather than `readsPrec`
* There is a warning L84 saying that the guards are non-exhaustive but they are. Is this something GHC can't figure out (which in this case I could understand). If so, do we suppress the warning or introduce a `otherwise`?
* more work to clean it up but it's starting to actually do something. Need to convert that into a `[Violation]` and print it