### PR TITLE
Output nothing if there is no report

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -48,5 +48,5 @@ main :: IO ()
 main = do
   options <- Opt.execParser opts
   (flip mapM_) (codeFilePaths options) $ \path -> do
-    (processFile path (githubKey options) >>= putStrLn . unpack . showViolations)
+    (processFile path (githubKey options) >>= putStr . unpack . showViolations)
     `catchAnyDeep` (\(SomeException e) -> hPutStrLn stderr [fmt|Error when processing {path}: {show e}|])


### PR DESCRIPTION
With `putStrLn`, even if the result of `showViolations` is empty, the
output is `\n`, resulting on output even if the report is empty.

This is highly unconvenient when `krank` is called on a batch of files,
such as `for i in $(git ls-files); do krank $i; done`

`putStr` does not happen the trailing newline and let this honor to showViolations.

This closes #15.