### PR TITLE
feat: CLI now handles many files at once

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,32 +1,41 @@
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
 import System.Environment (getArgs)
 import System.Exit (exitFailure)
+
+import System.IO (hPutStrLn, stderr)
 
 import Data.Semigroup ((<>))
 import Data.Text (unpack)
 import qualified Options.Applicative as Opt
-import Options.Applicative ((<**>))
+import Options.Applicative ((<**>), many)
+
+import Control.Exception.Safe
+import PyF
 
 import Krank
 import Krank.Formatter
 
 data KrankOpts = KrankOpts {
-  codeFilePath :: FilePath
+  codeFilePaths :: [FilePath]
 }
 
-fileToParse :: Opt.Parser FilePath
-fileToParse = Opt.argument Opt.str (Opt.metavar "FILE")
+filesToParse :: Opt.Parser [FilePath]
+filesToParse = many (Opt.argument Opt.str (Opt.metavar "FILES..."))
 
 sample :: Opt.Parser KrankOpts
-sample = KrankOpts <$> fileToParse
+sample = KrankOpts <$> filesToParse
 
 opts :: Opt.ParserInfo KrankOpts
 opts = Opt.info (sample <**> Opt.helper)
   ( Opt.fullDesc
-  <> Opt.progDesc "Checks the comments in FILE"
+  <> Opt.progDesc "Checks the comments in FILES"
   <> Opt.header "krank - a comment linter / analytics tool" )
 
 main :: IO ()
 main = do
   options <- Opt.execParser opts
-  violations <- processFile . codeFilePath $ options
-  putStrLn . unpack . showViolations $ violations
+  (flip mapM_) (codeFilePaths options) $ \path -> do
+    (processFile path >>= putStrLn . unpack . showViolations)
+    `catchAnyDeep` (\(SomeException e) -> hPutStrLn stderr [fmt|Error when processing {path}: {show e}|])

--- a/krank.cabal
+++ b/krank.cabal
@@ -55,5 +55,7 @@ executable krank
                        , optparse-applicative >= 0.14 && < 0.15
                        , text >= 1.2.3 && < 1.3
                        , krank
+                       , PyF
+                       , safe-exceptions
   hs-source-dirs:      app
   default-language:    Haskell2010


### PR DESCRIPTION
The feature is as simple as parsing `many` `FILE` arguments and mapping
over the list.

However, it introduces a regression because any file which fails during
parsing (file not found, not readable, invalide byte sequence, ...) will
kill the krank process.

I handle that with a `catchAnyDeep` which ensures that no synchroneous
exception will kill the process or stay silent.

In the future, it may be wise to do handle differently some of the
exceptions.

This closes #21. Krank can now be called such as `krank $(git
ls-files)`.

One drawback is that exceptions in a file kills the process