### PR TITLE
17 use GitHub token

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ Krank will parse you comment and check fact, so the code won't bitrot. For examp
 
 Check the github issues section to see the list of possible checkers.
 
+# Usage
+
+Just launch the `krank` command and pass a file or a list of files.  
+You can check `krank --help` for a list of options.  
+Additionally, the checker documentation pages might contain more information about checker specific
+option (See below)
+
+# Checkers
+
+[IssueTracker](docs/Checkers/IssueTracker.md)
 
 # Design guidelines
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -29,9 +29,9 @@ githubKeyToParse :: Opt.Parser (Maybe GithubKey)
 githubKeyToParse = optional (
   GithubKey <$> (
     Opt.strOption $
-      Opt.long "github-key"
+      Opt.long "issuetracker-githubkey"
       <> Opt.metavar "DEVELOPER_KEY"
-      <> Opt.help "A github developer key to allow for more API calls"))
+      <> Opt.help "A github developer key to allow for more API calls for the IssueTracker checker"))
 
 optionsParser :: Opt.Parser KrankOpts
 optionsParser = KrankOpts

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -3,29 +3,37 @@
 
 import System.Environment (getArgs)
 import System.Exit (exitFailure)
-
 import System.IO (hPutStrLn, stderr)
 
+import Control.Exception.Safe
+import Control.Applicative (optional)
 import Data.Semigroup ((<>))
 import Data.Text (unpack)
 import qualified Options.Applicative as Opt
 import Options.Applicative ((<**>), many)
-
-import Control.Exception.Safe
 import PyF
 
 import Krank
 import Krank.Formatter
 
 data KrankOpts = KrankOpts {
-  codeFilePaths :: [FilePath]
+  codeFilePaths :: [FilePath],
+  githubKey :: Maybe String
 }
 
 filesToParse :: Opt.Parser [FilePath]
 filesToParse = many (Opt.argument Opt.str (Opt.metavar "FILES..."))
 
+githubKeyToParse :: Opt.Parser (Maybe String)
+githubKeyToParse = optional $ Opt.strOption $
+  Opt.long "github-key"
+  <> Opt.metavar "DEVELOPER_KEY"
+  <> Opt.help "A github developer key to allow for more API calls"
+
 sample :: Opt.Parser KrankOpts
-sample = KrankOpts <$> filesToParse
+sample = KrankOpts
+  <$> filesToParse
+  <*> githubKeyToParse
 
 opts :: Opt.ParserInfo KrankOpts
 opts = Opt.info (sample <**> Opt.helper)
@@ -36,6 +44,7 @@ opts = Opt.info (sample <**> Opt.helper)
 main :: IO ()
 main = do
   options <- Opt.execParser opts
+  putStrLn $ show (githubKey options)
   (flip mapM_) (codeFilePaths options) $ \path -> do
     (processFile path >>= putStrLn . unpack . showViolations)
     `catchAnyDeep` (\(SomeException e) -> hPutStrLn stderr [fmt|Error when processing {path}: {show e}|])

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -44,7 +44,6 @@ opts = Opt.info (optionsParser <**> Opt.helper)
 main :: IO ()
 main = do
   options <- Opt.execParser opts
-  putStrLn $ show (githubKey options)
   (flip mapM_) (codeFilePaths options) $ \path -> do
-    (processFile path >>= putStrLn . unpack . showViolations)
+    (processFile path (githubKey options) >>= putStrLn . unpack . showViolations)
     `catchAnyDeep` (\(SomeException e) -> hPutStrLn stderr [fmt|Error when processing {path}: {show e}|])

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -19,18 +19,19 @@ import Krank.Types
 
 data KrankOpts = KrankOpts {
   codeFilePaths :: [FilePath],
-  githubKey :: GithubKey
+  githubKey :: Maybe GithubKey
 }
 
 filesToParse :: Opt.Parser [FilePath]
 filesToParse = many (Opt.argument Opt.str (Opt.metavar "FILES..."))
 
-githubKeyToParse :: Opt.Parser GithubKey
-githubKeyToParse = GithubKey <$> (
-  optional $ Opt.strOption $
-    Opt.long "github-key"
-    <> Opt.metavar "DEVELOPER_KEY"
-    <> Opt.help "A github developer key to allow for more API calls")
+githubKeyToParse :: Opt.Parser (Maybe GithubKey)
+githubKeyToParse = optional (
+  GithubKey <$> (
+    Opt.strOption $
+      Opt.long "github-key"
+      <> Opt.metavar "DEVELOPER_KEY"
+      <> Opt.help "A github developer key to allow for more API calls"))
 
 optionsParser :: Opt.Parser KrankOpts
 optionsParser = KrankOpts

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -15,20 +15,22 @@ import PyF
 
 import Krank
 import Krank.Formatter
+import Krank.Types
 
 data KrankOpts = KrankOpts {
   codeFilePaths :: [FilePath],
-  githubKey :: Maybe String
+  githubKey :: GithubKey
 }
 
 filesToParse :: Opt.Parser [FilePath]
 filesToParse = many (Opt.argument Opt.str (Opt.metavar "FILES..."))
 
-githubKeyToParse :: Opt.Parser (Maybe String)
-githubKeyToParse = optional $ Opt.strOption $
-  Opt.long "github-key"
-  <> Opt.metavar "DEVELOPER_KEY"
-  <> Opt.help "A github developer key to allow for more API calls"
+githubKeyToParse :: Opt.Parser GithubKey
+githubKeyToParse = GithubKey <$> (
+  optional $ Opt.strOption $
+    Opt.long "github-key"
+    <> Opt.metavar "DEVELOPER_KEY"
+    <> Opt.help "A github developer key to allow for more API calls")
 
 optionsParser :: Opt.Parser KrankOpts
 optionsParser = KrankOpts

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -30,13 +30,13 @@ githubKeyToParse = optional $ Opt.strOption $
   <> Opt.metavar "DEVELOPER_KEY"
   <> Opt.help "A github developer key to allow for more API calls"
 
-sample :: Opt.Parser KrankOpts
-sample = KrankOpts
+optionsParser :: Opt.Parser KrankOpts
+optionsParser = KrankOpts
   <$> filesToParse
   <*> githubKeyToParse
 
 opts :: Opt.ParserInfo KrankOpts
-opts = Opt.info (sample <**> Opt.helper)
+opts = Opt.info (optionsParser <**> Opt.helper)
   ( Opt.fullDesc
   <> Opt.progDesc "Checks the comments in FILES"
   <> Opt.header "krank - a comment linter / analytics tool" )

--- a/docs/Checkers/IssueTracker.md
+++ b/docs/Checkers/IssueTracker.md
@@ -1,0 +1,39 @@
+# IssueTracker
+
+## Purpose
+
+Looks for issue tracker references in the codebase. When those are put in comments, it's generally
+to signal that some code is there to workaround a library bug/limitation.
+This checker will inspect the issue status and warn if the issue mentioned is closed (meaning that
+the workaround might be now unnecessary)
+
+## Support
+
+**IssueTracker** currently supports the following list of issue trackers:
+* Github
+
+## Configuration
+
+### Github
+
+#### API rate limitation
+
+If you are inspecting a codebase that has many issue references, or if you are running `krank` often
+from the same IP, you might hit a Github rate limitation (60 api calls per hour for anonymous
+requests).
+To circumvent this, you can create a **Personal Access Token** and pass it to `krank` with the
+`--issuetracker-githubkey` option. Github API calls will now be authenticated and the rate limit
+will be 5000 API calls per hour.
+Note that for IssueTracker to be able to report on issues from public repositories, you don't need
+to give any scope at all to your **Personal Access Token**.
+
+To generate a **Personal Access Token**, consult [the following documentation](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line)
+
+#### Private repositories
+
+To get information about private repositories, you need to provide Github authentication to the
+**IssueTracker** checker.
+To do so, you need to generate a **Personal Access Token**
+([See
+documentation](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line))
+with the `repo` scope and pass it to `krank` with the `--issuetracker-githubkey` option

--- a/krank.cabal
+++ b/krank.cabal
@@ -31,6 +31,7 @@ library
                        , req >= 2.1.0 && < 2.2
                        , text >= 1.2.3 && < 1.3
                        , unordered-containers >= 0.2.10 && < 0.2.11
+                       , utf8-string >= 1.0.1.1 && < 1.1
   hs-source-dirs:      src
   ghc-options: -Wall
   default-language:    Haskell2010

--- a/src/Krank.hs
+++ b/src/Krank.hs
@@ -5,8 +5,9 @@ module Krank (
 import qualified Krank.Checkers.IssueTracker as IT
 import Krank.Types
 
-processFile :: FilePath
+processFile :: FilePath  -- ^ the file to analyze
+            -> Maybe String       -- ^ github developer key to circumvent API rate limit
             -> IO [Violation]
-processFile filePath = do
+processFile filePath mGithubKey = do
   content <- readFile filePath
-  IT.checkText content
+  IT.checkText content mGithubKey

--- a/src/Krank.hs
+++ b/src/Krank.hs
@@ -5,8 +5,8 @@ module Krank (
 import qualified Krank.Checkers.IssueTracker as IT
 import Krank.Types
 
-processFile :: FilePath  -- ^ the file to analyze
-            -> Maybe String       -- ^ github developer key to circumvent API rate limit
+processFile :: FilePath    -- ^ the file to analyze
+            -> GithubKey   -- ^ github developer key to circumvent API rate limit
             -> IO [Violation]
 processFile filePath mGithubKey = do
   content <- readFile filePath

--- a/src/Krank.hs
+++ b/src/Krank.hs
@@ -5,8 +5,8 @@ module Krank (
 import qualified Krank.Checkers.IssueTracker as IT
 import Krank.Types
 
-processFile :: FilePath    -- ^ the file to analyze
-            -> GithubKey   -- ^ github developer key to circumvent API rate limit
+processFile :: FilePath      -- ^ the file to analyze
+            -> Maybe GithubKey   -- ^ github developer key to circumvent API rate limit
             -> IO [Violation]
 processFile filePath mGithubKey = do
   content <- readFile filePath

--- a/src/Krank/Checkers/IssueTracker.hs
+++ b/src/Krank/Checkers/IssueTracker.hs
@@ -20,6 +20,7 @@ import Control.Applicative ((*>), optional)
 import Control.Exception (catch)
 import Data.Aeson (Value, (.:))
 import qualified Data.Aeson.Types as AesonT
+import qualified Data.ByteString.UTF8 as BSU
 import Data.Char (isDigit)
 import Data.Maybe (fromMaybe)
 import Data.Text (Text, pack)
@@ -92,19 +93,29 @@ issueUrl issue = case server issue of
 
 -- try Issue can fail, on non-2xx HTTP response
 tryRestIssue :: Req.Url 'Req.Https
+             -> Maybe String
              -> IO Value
-tryRestIssue url = Req.runReq Req.defaultHttpConfig $ do
-  r <- Req.req Req.GET url Req.NoReqBody Req.jsonResponse (Req.header "User-Agent" "krank")
-  pure $ Req.responseBody r
+tryRestIssue url mGithubKey = do
+  Req.runReq Req.defaultHttpConfig $ do
+    r <- Req.req Req.GET url Req.NoReqBody Req.jsonResponse (
+      Req.header "User-Agent" "krank"
+      <> authHeaders)
+    pure $ Req.responseBody r
+
+  where
+    authHeaders = case mGithubKey of
+      Just token -> Req.oAuth2Token (BSU.fromString token)
+      Nothing -> mempty
 
 httpExcHandler :: Req.Url 'Req.Https
                -> Req.HttpException
                -> IO Value
 httpExcHandler url _ = pure . AesonT.object $ [("error", AesonT.String . pack . show $ url)]
 
-restIssue :: Req.Url 'Req.Https
+restIssue :: Maybe String
+             -> Req.Url 'Req.Https
              -> IO Value
-restIssue url = catch (tryRestIssue url) (httpExcHandler url)
+restIssue mGithubKey url = catch (tryRestIssue url mGithubKey) (httpExcHandler url)
 
 statusParser :: Value
             -> Either Text IssueStatus
@@ -129,10 +140,11 @@ errorParser o = do
       readErr (AesonT.Error _) = "invalid JSON"
 
 gitIssuesWithStatus :: [GitIssue]
+                    -> Maybe String
                     -> IO [Either Text GitIssueWithStatus]
-gitIssuesWithStatus issues = do
+gitIssuesWithStatus issues mGithubKey = do
   let urls = issueUrl <$> issues
-  statuses <- mapM restIssue urls
+  statuses <- mapM (restIssue mGithubKey) urls
   pure $ zipWith f issues (fmap statusParser statuses)
     where
       f _ (Left err) = Left err
@@ -162,10 +174,11 @@ issueToMessage i = case issueStatus i of
     issue = gitIssue i
 
 checkText :: String
+          -> Maybe String
           -> IO [Violation]
-checkText t = do
+checkText t mGithubKey = do
   let issues = extractIssues t
-  issuesWithStatus <- gitIssuesWithStatus issues
+  issuesWithStatus <- gitIssuesWithStatus issues mGithubKey
   pure $ fmap f issuesWithStatus
     where
       f (Left err) = Violation issueTrackerChecker Warning "Url could not be reached" err
@@ -175,4 +188,4 @@ checkFile :: FilePath
       -> IO [Violation]
 checkFile file = do
   content <- readFile file
-  checkText content
+  checkText content Nothing

--- a/src/Krank/Types.hs
+++ b/src/Krank/Types.hs
@@ -1,9 +1,12 @@
 module Krank.Types (
-  Violation(..)
+  GithubKey(..)
+  , Violation(..)
   , ViolationLevel(..)
   ) where
 
 import Data.Text (Text)
+
+newtype GithubKey = GithubKey (Maybe String)
 
 data ViolationLevel = Info | Warning | Error deriving (Show)
 

--- a/src/Krank/Types.hs
+++ b/src/Krank/Types.hs
@@ -6,7 +6,7 @@ module Krank.Types (
 
 import Data.Text (Text)
 
-newtype GithubKey = GithubKey (Maybe String)
+newtype GithubKey = GithubKey String
 
 data ViolationLevel = Info | Warning | Error deriving (Show)
 


### PR DESCRIPTION
`--github-key` as a command line argument to pass a personal github token. 

Circumvents the rate limit issue and gives access to private repo (providing the token has the right scopes)