### PR TITLE
Improve outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision history for krank
 
+* Output is more compact and more detailled
+* Output is now colored (can be disabled with `--no-colors`)
+
 ## 0.1.0.0 -- 2019-10-21
 
 * First version. Released on an unsuspecting world.

--- a/README.md
+++ b/README.md
@@ -13,17 +13,11 @@ informations found in the comments:
 ```bash
 $ krank $(git ls-files)
 
-[Info] issue #2733 still Open
-    in: NixOS/nix
-    file: default.nix:20:20
+default.nix:20:20: info:
+  still Open: https://github.com/NixOS/nix/issues/2733
 
-[Error] issue #6313 is now Closed
-    in: bazelbuild/bazel
-    file: default.nix:67:11
-
-[Error] issue #22 is now Closed
-    in: guibou/PyF
-    file: src/Foo.hs:100:4
+foo.hs:67:11: error:
+  is now Closed: https://github.com/bazelbuild/bazel/issues/6313
 ```
 
 Here `krank` is telling us that our source code links to github

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ default.nix:20:20: info:
   still Open: https://github.com/NixOS/nix/issues/2733
 
 foo.hs:67:11: error:
-  is now Closed: https://github.com/bazelbuild/bazel/issues/6313
+  now Closed: https://github.com/bazelbuild/bazel/issues/6313
 ```
 
 Here `krank` is telling us that our source code links to github

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -6,6 +6,8 @@ import Data.Semigroup ((<>))
 import qualified Options.Applicative as Opt
 import Options.Applicative ((<**>), many)
 
+import System.Console.Pretty
+
 import Krank
 import Krank.Types
 
@@ -32,6 +34,8 @@ optionsParser = KrankOpts
        <$> githubKeyToParse
        <*> (Opt.switch $ Opt.long "dry-run"
         <> Opt.help "Perform a dry run. Parse file, but do not execute HTTP requests")
+      <*> (not <$> (Opt.switch $ Opt.long "no-colors"
+           <> Opt.help "Disable colored outputs"))
       )
 
 opts :: Opt.ParserInfo KrankOpts
@@ -42,6 +46,13 @@ opts = Opt.info (optionsParser <**> Opt.helper)
 
 main :: IO ()
 main = do
+  canUseColor <- supportsPretty
+
   config <- Opt.execParser opts
 
-  runKrank (codeFilePaths config) (krankConfig config)
+  let
+    kConfig = (krankConfig config) {
+      useColors = useColors (krankConfig config) && canUseColor
+      }
+
+  runKrank (codeFilePaths config) kConfig

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -6,7 +6,7 @@ import Data.Semigroup ((<>))
 import qualified Options.Applicative as Opt
 import Options.Applicative ((<**>), many)
 
-import System.Console.Pretty
+import System.Console.Pretty (supportsPretty)
 
 import Krank
 import Krank.Types
@@ -27,6 +27,11 @@ githubKeyToParse = optional (
       <> Opt.metavar "DEVELOPER_KEY"
       <> Opt.help "A github developer key to allow for more API calls for the IssueTracker checker"))
 
+noColorParse :: Opt.Parser Bool
+noColorParse = not <$> Opt.switch (
+  Opt.long "no-colors"
+    <> Opt.help "Disable colored outputs")
+
 optionsParser :: Opt.Parser KrankOpts
 optionsParser = KrankOpts
   <$> filesToParse
@@ -34,8 +39,7 @@ optionsParser = KrankOpts
        <$> githubKeyToParse
        <*> (Opt.switch $ Opt.long "dry-run"
         <> Opt.help "Perform a dry run. Parse file, but do not execute HTTP requests")
-      <*> (not <$> (Opt.switch $ Opt.long "no-colors"
-           <> Opt.help "Disable colored outputs"))
+       <*> noColorParse
       )
 
 opts :: Opt.ParserInfo KrankOpts

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,19 +1,12 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
 
-import System.IO (hPutStrLn, stderr)
-
-import Control.Exception.Safe
 import Control.Applicative (optional)
 import Data.Semigroup ((<>))
-import Data.Text (unpack)
 import qualified Options.Applicative as Opt
 import Options.Applicative ((<**>), many)
-import Control.Monad.Reader
-import PyF
 
 import Krank
-import Krank.Formatter
 import Krank.Types
 
 data KrankOpts = KrankOpts {
@@ -47,14 +40,8 @@ opts = Opt.info (optionsParser <**> Opt.helper)
   <> Opt.progDesc "Checks the comments in FILES"
   <> Opt.header "krank - a comment linter / analytics tool" )
 
-runKrank :: FilePath -> KrankConfig -> IO ()
-runKrank path options = do
-  violations <- runReaderT (processFile path) options
-  putStr . unpack . showViolations $ violations
-
 main :: IO ()
 main = do
-  options <- Opt.execParser opts
-  (flip mapM_) (codeFilePaths options) $ \path -> do
-    (runKrank path (krankConfig options))
-    `catchAnyDeep` (\(SomeException e) -> hPutStrLn stderr [fmt|Error when processing {path}: {show e}|])
+  config <- Opt.execParser opts
+
+  runKrank (codeFilePaths config) (krankConfig config)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
 
-import System.Environment (getArgs)
-import System.Exit (exitFailure)
 import System.IO (hPutStrLn, stderr)
 
 import Control.Exception.Safe

--- a/krank.cabal
+++ b/krank.cabal
@@ -54,11 +54,7 @@ executable krank
   main-is:             Main.hs
   build-depends:       base >=4.12 && <4.13
                        , optparse-applicative >= 0.14 && < 0.15
-                       , text >= 1.2.3 && < 1.3
                        , krank
-                       , PyF
-                       , safe-exceptions
-                       , mtl
   hs-source-dirs:      app
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/krank.cabal
+++ b/krank.cabal
@@ -61,3 +61,4 @@ executable krank
                        , mtl
   hs-source-dirs:      app
   default-language:    Haskell2010
+  ghc-options:         -Wall

--- a/krank.cabal
+++ b/krank.cabal
@@ -32,6 +32,7 @@ library
                        , megaparsec
                        , mtl
                        , safe-exceptions
+                       , pretty-terminal
   hs-source-dirs:      src
   ghc-options: -Wall
   default-language:    Haskell2010
@@ -55,6 +56,7 @@ executable krank
   build-depends:       base >=4.12 && <4.13
                        , optparse-applicative >= 0.14 && < 0.15
                        , krank
+                       , pretty-terminal
   hs-source-dirs:      app
   default-language:    Haskell2010
   ghc-options:         -Wall

--- a/src/Krank.hs
+++ b/src/Krank.hs
@@ -1,13 +1,30 @@
+{-# LANGUAGE QuasiQuotes #-}
+
 module Krank (
-  processFile
+  runKrank
   ) where
 
 import qualified Krank.Checkers.IssueTracker as IT
 import Krank.Types
 import Control.Monad.Reader
+import Control.Exception.Safe
+import PyF
+import System.IO (hPutStrLn, stderr)
+import Data.Text (unpack)
+
+import Krank.Formatter
 
 processFile :: FilePath      -- ^ the file to analyze
-            -> ReaderT KrankConfig IO [Violation]
+            -> ReaderT KrankConfig IO ()
 processFile filePath = do
   content <- liftIO $ readFile filePath
-  IT.checkText filePath content
+
+  violations <- IT.checkText filePath content
+
+  liftIO $ putStr . unpack . showViolations $ violations
+
+runKrank :: [FilePath] -> KrankConfig -> IO ()
+runKrank paths options = (flip runReaderT) options $ do
+  (flip mapM_) paths $ \path -> do
+    processFile path `catchAny`
+      (\(SomeException e) -> liftIO $ hPutStrLn stderr [fmt|Error when processing {path}: {show e}|])

--- a/src/Krank.hs
+++ b/src/Krank.hs
@@ -18,12 +18,10 @@ import Krank.Formatter
 processFile :: FilePath      -- ^ the file to analyze
             -> ReaderT KrankConfig IO ()
 processFile filePath = do
-  content <- liftIO $ readFile filePath
-
-  violations <- IT.checkText filePath content
-
   KrankConfig{useColors} <- ask
 
+  content <- liftIO $ readFile filePath
+  violations <- IT.checkText filePath content
   liftIO $ putStr . unpack . foldMap (showViolation useColors) $ violations
 
 runKrank :: [FilePath] -> KrankConfig -> IO ()

--- a/src/Krank.hs
+++ b/src/Krank.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE NamedFieldPuns #-}
 
 module Krank (
   runKrank
@@ -21,7 +22,9 @@ processFile filePath = do
 
   violations <- IT.checkText filePath content
 
-  liftIO $ putStr . unpack . showViolations $ violations
+  KrankConfig{useColors} <- ask
+
+  liftIO $ putStr . unpack . foldMap (showViolation useColors) $ violations
 
 runKrank :: [FilePath] -> KrankConfig -> IO ()
 runKrank paths options = (flip runReaderT) options $ do

--- a/src/Krank/Checkers/IssueTracker.hs
+++ b/src/Krank/Checkers/IssueTracker.hs
@@ -182,7 +182,7 @@ issueToMessage :: GitIssueWithStatus
                -> Text
 issueToMessage i = case issueStatus i of
   Open   -> [fmt|still Open|]
-  Closed -> [fmt|is now Closed|]
+  Closed -> [fmt|now Closed|]
 
 issuePrintUrl :: GitIssue -> Text
 issuePrintUrl GitIssue{owner, repo, server, issueNum} = [fmt|https://{serverDomain server}/{owner}/{repo}/issues/{issueNum}|]

--- a/src/Krank/Formatter.hs
+++ b/src/Krank/Formatter.hs
@@ -4,28 +4,31 @@
 {-# LANGUAGE NamedFieldPuns #-}
 
 module Krank.Formatter (
-  showViolations
+  showViolation
   ) where
 
 import Data.Text (Text)
 import PyF (fmt)
 import Text.Megaparsec.Pos (sourcePosPretty)
+import System.Console.Pretty
 
 import Krank.Types
 
-showViolations :: [Violation]
-               -> Text
-showViolations = foldMap showViolation
-
-showViolation :: Violation
-              -> Text
-showViolation Violation{checker, location, level, message} = [fmt|
-{sourcePosPretty $ location}: {showViolationLevel level}:
+showViolation
+  :: Bool
+  -> Violation
+  -> Text
+showViolation useColors Violation{checker, location, level, message} = [fmt|
+{sourcePosPretty $ location}: {showViolationLevel useColors level}:
   {message}: {checker}
 |]
 
-showViolationLevel :: ViolationLevel -> String
-showViolationLevel = \case
-  Info -> "info"
-  Warning -> "warning"
-  Error -> "error"
+showViolationLevel :: Bool -> ViolationLevel -> String
+showViolationLevel enableColor = \case
+  Info -> colorized Green "info"
+  Warning -> colorized Magenta "warning"
+  Error -> colorized Red "error"
+  where
+    colorized c
+      | enableColor = style Bold . color c
+      | otherwise = id

--- a/src/Krank/Formatter.hs
+++ b/src/Krank/Formatter.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
 
 module Krank.Formatter (
   showViolations
@@ -17,8 +19,13 @@ showViolations = foldMap showViolation
 
 showViolation :: Violation
               -> Text
-showViolation violation = [fmt|
-[{(show (level violation))}] {message violation}
-    in: {snippet violation}
-    file: {sourcePosPretty (location violation)}
+showViolation Violation{checker, location, level, message} = [fmt|
+{sourcePosPretty $ location}: {showViolationLevel level}:
+  {message}: {checker}
 |]
+
+showViolationLevel :: ViolationLevel -> String
+showViolationLevel = \case
+  Info -> "info"
+  Warning -> "warning"
+  Error -> "error"

--- a/src/Krank/Formatter.hs
+++ b/src/Krank/Formatter.hs
@@ -19,7 +19,7 @@ showViolation
   -> Violation
   -> Text
 showViolation useColors Violation{checker, location, level, message} = [fmt|
-{sourcePosPretty $ location}: {showViolationLevel useColors level}:
+{sourcePosPretty location}: {showViolationLevel useColors level}:
   {message}: {checker}
 |]
 

--- a/src/Krank/Types.hs
+++ b/src/Krank/Types.hs
@@ -25,5 +25,9 @@ data Violation = Violation { checker :: Text
 
 data KrankConfig = KrankConfig
   { githubKey :: Maybe GithubKey
+  -- ^ The github oAuth token
   , dryRun :: Bool
+  -- ^ If 'True', all IO operations, such as HTTP requests, are ignored
+  , useColors :: Bool
+  -- ^ Use color for formatting
   }

--- a/src/Krank/Types.hs
+++ b/src/Krank/Types.hs
@@ -13,10 +13,14 @@ newtype GithubKey = GithubKey String
 data ViolationLevel = Info | Warning | Error deriving (Show)
 
 data Violation = Violation { checker :: Text
+                             -- ^ A textual representation of the checker. Most of the time that's
+                             -- the chunck of text parsed
                            , level :: ViolationLevel
-                           , snippet :: Text
+                           -- ^ The 'ViolationLevel' associated with the result
                            , message :: Text
+                           -- ^ A message describing the error
                            , location :: SourcePos
+                           -- ^ The position in the input sources of the chunck
                            } deriving (Show)
 
 data KrankConfig = KrankConfig


### PR DESCRIPTION
Closes #32.

The quality of output is improved:

- More compact
- Each status line contains a full github URL, which is easier to click (if needed)
- Status warning (error / info / warning) are now colored
- Dry-run messages are not displayed as "request failures".

The output now looks like:

```
default.nix:20:20: info:
  still Open: https://github.com/NixOS/nix/issues/2733

foo.hs:67:11: error:
  is now Closed: https://github.com/bazelbuild/bazel/issues/6313
```