### PR TITLE
Use `regex-pcre`

### DIFF
--- a/krank.cabal
+++ b/krank.cabal
@@ -31,6 +31,7 @@ library
                        , mtl
                        , safe-exceptions
                        , pretty-terminal
+                       , bytestring
   hs-source-dirs:      src
   ghc-options: -Wall
   default-language:    Haskell2010
@@ -46,7 +47,7 @@ test-suite krank-test
                        , PyF >= 0.8.1.0 && < 0.9
                        , krank
                        , pcre-heavy
-                       , text
+                       , bytestring
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 

--- a/krank.cabal
+++ b/krank.cabal
@@ -27,8 +27,7 @@ library
                        , req >= 2.1.0 && < 2.2
                        , text >= 1.2.3 && < 1.3
                        , unordered-containers >= 0.2.10 && < 0.2.11
-                       , replace-megaparsec
-                       , megaparsec
+                       , pcre-heavy
                        , mtl
                        , safe-exceptions
                        , pretty-terminal
@@ -46,7 +45,8 @@ test-suite krank-test
                        , hspec >= 2.7 && < 2.8
                        , PyF >= 0.8.1.0 && < 0.9
                        , krank
-                       , megaparsec
+                       , pcre-heavy
+                       , text
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 

--- a/src/Krank.hs
+++ b/src/Krank.hs
@@ -21,7 +21,7 @@ processFile :: FilePath      -- ^ the file to analyze
 processFile filePath = do
   KrankConfig{useColors} <- ask
 
-  content <- liftIO $ readFile filePath
+  content <- liftIO $ Text.IO.readFile filePath
   violations <- IT.checkText filePath content
   liftIO $ Text.IO.putStr . foldMap (showViolation useColors) $ violations
 

--- a/src/Krank.hs
+++ b/src/Krank.hs
@@ -13,6 +13,7 @@ import Control.Exception.Safe
 import PyF
 import System.IO (stderr)
 import qualified Data.Text.IO as Text.IO
+import qualified Data.ByteString
 
 import Krank.Formatter
 
@@ -21,7 +22,7 @@ processFile :: FilePath      -- ^ the file to analyze
 processFile filePath = do
   KrankConfig{useColors} <- ask
 
-  content <- liftIO $ Text.IO.readFile filePath
+  content <- liftIO $ Data.ByteString.readFile filePath
   violations <- IT.checkText filePath content
   liftIO $ Text.IO.putStr . foldMap (showViolation useColors) $ violations
 

--- a/src/Krank/Checkers/IssueTracker.hs
+++ b/src/Krank/Checkers/IssueTracker.hs
@@ -65,7 +65,7 @@ serverDomain Gitlab = "gitlab.com"
 
 -- | This regex represents a github/gitlab issue URL
 gitRepoRe :: Regex
-gitRepoRe = [re|(?:https?://)?(?:www.)?(github.com|gitlab.com)/([^/]+)/([^/]+)/issues/([0-9]+)|]
+gitRepoRe = [re|(?:https?://)?(?:www\.)?(github\.com|gitlab\.com)/([^/]+)/([^/]+)/issues/([0-9]+)|]
 
 -- | Extract all issues on one line and returns a list of the raw text associated with an issue
 extractIssuesOnALine :: ByteString -> [(Int, GitIssue)]

--- a/src/Krank/Formatter.hs
+++ b/src/Krank/Formatter.hs
@@ -9,7 +9,6 @@ module Krank.Formatter (
 
 import Data.Text (Text)
 import PyF (fmt)
-import Text.Megaparsec.Pos (sourcePosPretty)
 import System.Console.Pretty
 
 import Krank.Types
@@ -19,7 +18,7 @@ showViolation
   -> Violation
   -> Text
 showViolation useColors Violation{checker, location, level, message} = [fmt|
-{sourcePosPretty location}: {showViolationLevel useColors level}:
+{showSourcePos location}: {showViolationLevel useColors level}:
   {message}: {checker}
 |]
 
@@ -32,3 +31,7 @@ showViolationLevel enableColor = \case
     colorized c
       | enableColor = style Bold . color c
       | otherwise = id
+
+
+showSourcePos :: SourcePos -> String
+showSourcePos (SourcePos path line column) = [fmt|{path}:{line}:{column}|]

--- a/src/Krank/Types.hs
+++ b/src/Krank/Types.hs
@@ -4,15 +4,17 @@ module Krank.Types (
   , Violation(..)
   , ViolationLevel(..)
   , KrankConfig(..)
+  , SourcePos(..)
   ) where
 
 import Data.Text (Text)
-import Text.Megaparsec (SourcePos)
 
 newtype GithubKey = GithubKey Text
 newtype GitlabKey = GitlabKey Text
 
 data ViolationLevel = Info | Warning | Error deriving (Show)
+data SourcePos = SourcePos FilePath Int Int
+  deriving (Show, Eq, Ord)
 
 data Violation = Violation { checker :: Text
                              -- ^ A textual representation of the checker. Most of the time that's

--- a/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
+++ b/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
@@ -10,9 +10,9 @@ import Test.Hspec
 
 import Krank.Checkers.IssueTracker
 import Krank.Types
-import Data.Text
+import Data.ByteString.Char8 (ByteString)
 
-check :: Text -> Maybe GitIssue
+check :: ByteString -> Maybe GitIssue
 check a = case extractIssuesOnALine a of
   [(_, x)] -> Just x
   _ -> Nothing

--- a/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
+++ b/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
@@ -26,6 +26,12 @@ giturlTests domain = do
     let match = check [fmt|https://{domainName}/guibou/krank/issues/1|]
     match `shouldBe` (Just $ GitIssue domain "guibou" "krank" 1)
 
+  it "Does not wildcard . in domain name" $ do
+    let match = check [fmt|https://{map replaceDot domainName}/guibou/krank/issues/1|]
+        replaceDot '.' = 'X'
+        replaceDot x = x
+    match `shouldBe` Nothing
+
   it "handles full http url" $ do
     let match = check [fmt|http://{domainName}/guibou/krank/issues/1|]
     match `shouldBe` (Just $ GitIssue domain "guibou" "krank" 1)
@@ -34,9 +40,15 @@ giturlTests domain = do
     let match = check [fmt|{domainName}/guibou/krank/issues/1|]
     match `shouldBe` (Just $ GitIssue domain "guibou" "krank" 1)
 
-  it "accepts www in url" $ do
+  it "accepts www. in url" $ do
     let match = check [fmt|https://www.{domainName}/guibou/krank/issues/1|]
     match `shouldBe` (Just $ GitIssue domain "guibou" "krank" 1)
+
+  -- disabled for now
+  -- whatever happen it will match after wwwX.
+  xit "refuses wwwX" $ do -- to avoid matching dots in url
+    let match = check [fmt|https://wwwX{domainName}/guibou/krank/issues/1|]
+    match `shouldBe` Nothing
 
   it "accepts www in url - no protocol" $ do
     let match = check [fmt|www.{domainName}/guibou/krank/issues/1|]


### PR DESCRIPTION
This new approach uses `regex-pcre` instead of `megaparsec`.

The main improvements are:

- a dramatic performance improvement. CPU time is reduced by 10 and memory is reduced by 2
- less dependencies.