### PR TITLE
Parallel

### DIFF
--- a/krank.cabal
+++ b/krank.cabal
@@ -32,6 +32,7 @@ library
                        , safe-exceptions
                        , pretty-terminal
                        , bytestring
+                       , lifted-async
   hs-source-dirs:      src
   ghc-options: -Wall
   default-language:    Haskell2010
@@ -59,4 +60,4 @@ executable krank
                        , pretty-terminal
   hs-source-dirs:      app
   default-language:    Haskell2010
-  ghc-options:         -Wall
+  ghc-options:         -Wall -threaded -rtsopts

--- a/src/Krank/Checkers/IssueTracker.hs
+++ b/src/Krank/Checkers/IssueTracker.hs
@@ -30,7 +30,7 @@ import Control.Monad.Reader
 import Text.Regex.PCRE.Heavy
 import qualified Data.ByteString.Char8 as ByteString
 import Data.ByteString.Char8 (ByteString)
-
+import Control.Concurrent.Async.Lifted
 
 import Krank.Types
 
@@ -172,7 +172,7 @@ errorParser o = do
 gitIssuesWithStatus :: [Localized GitIssue]
                     -> ReaderT KrankConfig IO [Either (Text, Localized GitIssue) GitIssueWithStatus]
 gitIssuesWithStatus issues = do
-  statuses <- mapM restIssue issues
+  statuses <- mapConcurrently restIssue issues
   pure $ zipWith f issues (fmap statusParser statuses)
     where
       f issue (Left err) = Left (err, issue)


### PR DESCRIPTION
This PR is built on top of #37, so don't merge this before it is rebased on a merged #37.

This introduces parallel execution of the code for a dramatic performance improvement. 77 queries on 500K lines of code are handled in less than 2s instead of 40s.

See the different commits for details. The best things about it is that it does not even need threading (the performance improvement comes with `-N1`): everything is just done by the parallel IO scheduler.