### PR TITLE
Start regex on word boundary

### DIFF
--- a/src/Krank/Checkers/IssueTracker.hs
+++ b/src/Krank/Checkers/IssueTracker.hs
@@ -65,7 +65,9 @@ serverDomain Gitlab = "gitlab.com"
 
 -- | This regex represents a github/gitlab issue URL
 gitRepoRe :: Regex
-gitRepoRe = [re|(?:https?://)?(?:www\.)?(github\.com|gitlab\.com)/([^/]+)/([^/]+)/issues/([0-9]+)|]
+-- NOTE: \b at the beginning is really import for performances
+-- because it dramatically reduces the number of backtracks
+gitRepoRe = [re|\b(?:https?://)?(?:www\.)?(github\.com|gitlab\.com)/([^/]+)/([^/]+)/issues/([0-9]+)|]
 
 -- | Extract all issues on one line and returns a list of the raw text associated with an issue
 extractIssuesOnALine :: ByteString -> [(Int, GitIssue)]

--- a/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
+++ b/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
@@ -44,9 +44,7 @@ giturlTests domain = do
     let match = check [fmt|https://www.{domainName}/guibou/krank/issues/1|]
     match `shouldBe` (Just $ GitIssue domain "guibou" "krank" 1)
 
-  -- disabled for now
-  -- whatever happen it will match after wwwX.
-  xit "refuses wwwX" $ do -- to avoid matching dots in url
+  it "refuses wwwX" $ do -- to avoid matching dots in url
     let match = check [fmt|https://wwwX{domainName}/guibou/krank/issues/1|]
     match `shouldBe` Nothing
 


### PR DESCRIPTION
The direct impact is that less issues will be matched. For example the following won't be
matched:

- forbarbazhttp://github.com (needs a space)
- wwwxgithub.com (x should be a dot)

I don't think that's an issue for the first point.

Another interesting point is that it is faster:

- 300ms versus 600ms

- It also make #40 non necessary and improves the future of #39 because
with this change replacing the domain name by `[^/]` reduces the time
from 5s to 450ms (still faster than the current implementation!)