### PR TITLE
feature: generic gitlab support

### DIFF
--- a/krank.cabal
+++ b/krank.cabal
@@ -33,6 +33,7 @@ library
                        , pretty-terminal
                        , bytestring
                        , lifted-async
+                       , containers
   hs-source-dirs:      src
   ghc-options: -Wall
   default-language:    Haskell2010
@@ -49,6 +50,7 @@ test-suite krank-test
                        , krank
                        , pcre-heavy
                        , bytestring
+                       , text
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 
@@ -58,6 +60,10 @@ executable krank
                        , optparse-applicative >= 0.14 && < 0.15
                        , krank
                        , pretty-terminal
+                       , pcre-heavy
+                       , text
+                       , PyF
+                       , containers
   hs-source-dirs:      app
   default-language:    Haskell2010
   ghc-options:         -Wall -threaded -rtsopts

--- a/src/Krank/Types.hs
+++ b/src/Krank/Types.hs
@@ -1,6 +1,7 @@
 module Krank.Types (
   GithubKey(..)
   , GitlabKey(..)
+  , GitlabHost(..)
   , Violation(..)
   , ViolationLevel(..)
   , KrankConfig(..)
@@ -8,9 +9,11 @@ module Krank.Types (
   ) where
 
 import Data.Text (Text)
+import Data.Map (Map)
 
-newtype GithubKey = GithubKey Text
-newtype GitlabKey = GitlabKey Text
+newtype GithubKey = GithubKey Text deriving (Show)
+newtype GitlabKey = GitlabKey Text deriving (Show)
+newtype GitlabHost = GitlabHost Text deriving (Show, Ord, Eq)
 
 data ViolationLevel = Info | Warning | Error deriving (Show)
 data SourcePos = SourcePos FilePath Int Int
@@ -30,10 +33,11 @@ data Violation = Violation { checker :: Text
 data KrankConfig = KrankConfig
   { githubKey :: Maybe GithubKey
   -- ^ The github oAuth token
-  , gitlabKey :: Maybe GitlabKey
+  , gitlabKeys :: Map GitlabHost GitlabKey
   -- ^ The gitlab oAuth token
   , dryRun :: Bool
   -- ^ If 'True', all IO operations, such as HTTP requests, are ignored
   , useColors :: Bool
   -- ^ Use color for formatting
   }
+  deriving (Show)


### PR DESCRIPTION
Closes #39

This implements parsing and check for arbitrary gitlab instances.

This is achieved by changing the parsing regex so that it parse any
arbitrary host before `/user/repo/issues/XXXX`.

Performances of the parsing are a bit impacted by this arbitrary
parsing. On my huge codebase, its increased from 300ms to 500ms, which
is perfectly fine.

One drawback of this implementation is that it now may parse any url
ending by `/usr/repo/issues/XXXX` even if they are pointing to a totally
irrelevant host. This will also make an api QUERY to this host. For
example, if your files contains https://foobarbaz/foo/bar/issues/1234,
host foobarbaz will be queried. QUESTION: is this a security issue?

Tests were removed to account for the less restrictive policy about
host.

Command-line API is changed for gitlab keys, you now need to pass option
`--issuetracker-gitlabhost=HOST=KEY`.