### PR TITLE
Restore stack in the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,8 @@ jobs:
             - cci-demo-haskell-v1-{{ checksum "stack.yaml" }}
       - run:
           name: Build dependencies
-          command: stack test --only-dependencies
+          # Note: --jobs=1 because else it hit the circle CI memory limit
+          command: stack test --only-dependencies --jobs=1
       - save_cache:
           name: Cache Dependencies
           key: cci-demo-haskell-v1-{{ checksum "stack.yaml" }}-{{ checksum "krank.cabal" }}
@@ -45,13 +46,11 @@ jobs:
             - ".stack-work"
       - run:
           name: Build
-          command: stack test
+          command: stack test --jobs=1
 
 workflows:
   version: 2
   nix_stack:
     jobs:
       - nix
-# Disable stack build, it takes too much memory and time. We'll see for release
-# how it build with stack and push it to lts.
-#      - stack
+      - stack

--- a/krank.cabal
+++ b/krank.cabal
@@ -21,7 +21,6 @@ library
                        Krank.Checkers.IssueTracker
                        Krank.Formatter
                        Krank.Types
-
   other-modules:       Utils.Req
 
   build-depends:       base >= 4.9 && < 5.0
@@ -50,8 +49,8 @@ test-suite krank-test
   other-modules:       Test.Krank.Checkers.IssueTrackerSpec
   build-tools:
   build-depends:       base
-                       , hspec >= 2.7 && < 2.8
-                       , PyF >= 0.8.1.0 && < 0.9
+                       , hspec >= 2.7
+                       , PyF >= 0.8.1.0
                        , krank
                        , pcre-heavy
                        , bytestring
@@ -61,8 +60,8 @@ test-suite krank-test
 
 executable krank
   main-is:             Main.hs
-  build-depends:       base >=4.12 && <4.13
-                       , optparse-applicative >= 0.14 && < 0.15
+  build-depends:       base >=4.9
+                       , optparse-applicative >= 0.14
                        , krank
                        , pretty-terminal
                        , pcre-heavy

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,8 +1,9 @@
-resolver: lts-14.6
+resolver: nightly-2020-02-08
 
 packages:
 - .
 
-# PyF was removed from lts and nightly without notice
 extra-deps:
-- PyF-0.8.1.1@sha256:bd9369c55968b3b6be251c66e513b77af22ccc9fa60b6343ab6ff7d851cf28cd,2567
+- pretty-terminal-0.1.0.0@sha256:e9135d86ebb2a8e3aaf5a79088de4628dbd49988388e0fbfc26c5ecb3c399ad9,1638
+
+


### PR DESCRIPTION
Now that PyF is in stackage.

Note that I'm not using an LTS because PyF keep disapearing from
stackage: see this issue for more details: https://github.com/commercialhaskell/lts-haskell/issues/254