### PR TITLE
feat: show raw HTTP response in case of error

### DIFF
--- a/krank.cabal
+++ b/krank.cabal
@@ -24,6 +24,7 @@ library
 
   build-depends:       base >= 4.9 && < 5.0
                        , aeson >= 1.4.4 && < 1.5
+                       , http-client >= 0.6 && < 0.7
                        , PyF >= 0.8.1.0 && < 0.9
                        , req >= 2.1.0 && < 2.2
                        , text >= 1.2.3 && < 1.3

--- a/krank.cabal
+++ b/krank.cabal
@@ -22,6 +22,8 @@ library
                        Krank.Formatter
                        Krank.Types
 
+  other-modules:       Utils.Req
+
   build-depends:       base >= 4.9 && < 5.0
                        , aeson >= 1.4.4 && < 1.5
                        , http-client >= 0.6 && < 0.7

--- a/krank.cabal
+++ b/krank.cabal
@@ -27,6 +27,7 @@ library
   build-depends:       base >= 4.9 && < 5.0
                        , aeson >= 1.4.4 && < 1.5
                        , http-client >= 0.6 && < 0.7
+                       , http-types >= 0.12 && < 0.13
                        , PyF >= 0.8.1.0 && < 0.9
                        , req >= 2.1.0 && < 2.2
                        , text >= 1.2.3 && < 1.3

--- a/src/Krank/Checkers/IssueTracker.hs
+++ b/src/Krank/Checkers/IssueTracker.hs
@@ -143,8 +143,6 @@ httpExcHandler issue exc = pure . AesonT.object $ [("error", AesonT.String . pac
   [fmt|
     Error:
       {(showHTTPException exc)}
-    Requested URL:
-      {(show $ issueUrl . unLocalized $ issue)}
   |])]
 
 restIssue :: Localized GitIssue

--- a/src/Krank/Checkers/IssueTracker.hs
+++ b/src/Krank/Checkers/IssueTracker.hs
@@ -28,12 +28,12 @@ import Data.ByteString.Char8 (ByteString)
 import qualified Data.Map as Map
 import Data.Text (Text, pack)
 import qualified Data.Text.Encoding as Text.Encoding
-import qualified Network.HTTP.Client as Client
 import qualified Network.HTTP.Req as Req
 import PyF (fmt)
 import qualified Text.Regex.PCRE.Heavy as RE
 
 import Krank.Types
+import Utils.Req
 
 data GitServer = Github | Gitlab GitlabHost
   deriving (Eq, Show)
@@ -135,12 +135,6 @@ headersFor issue = do
     Gitlab host -> case Map.lookup host mGitlabKeys of
       Just (GitlabKey token) -> pure $ Req.header "PRIVATE-TOKEN" (Text.Encoding.encodeUtf8 token)
       Nothing -> pure mempty
-
-showHTTPException :: Req.HttpException
-                  -> String
-showHTTPException (Req.VanillaHttpException (Client.HttpExceptionRequest _ resp)) = show resp
--- Catch all doing a simple and ugly show
-showHTTPException exc = show exc
 
 httpExcHandler :: Localized GitIssue
                -> Req.HttpException

--- a/src/Utils/Req.hs
+++ b/src/Utils/Req.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE DataKinds #-}
+
+module Utils.Req (
+  showHTTPException
+  ) where
+
+import Data.Text (Text, pack)
+import qualified Network.HTTP.Client as Client
+import qualified Network.HTTP.Req as Req
+
+showHTTPException :: Req.HttpException
+                  -> Text
+showHTTPException (Req.VanillaHttpException clientHttpException) = showClientHttpException clientHttpException
+showHTTPException (Req.JsonHttpException exc) = pack exc
+
+showClientHttpException :: Client.HttpException
+                        -> Text
+showClientHttpException (Client.HttpExceptionRequest _ excContent) = showExceptionContent excContent
+showClientHttpException (Client.InvalidUrlException _ reason) = pack reason
+
+showExceptionContent :: Client.HttpExceptionContent
+                     -> Text
+-- Catch all doing a simple and ugly show
+showExceptionContent exc = pack . show $ exc

--- a/src/Utils/Req.hs
+++ b/src/Utils/Req.hs
@@ -1,12 +1,17 @@
-{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 module Utils.Req (
   showHTTPException
   ) where
 
+import Data.ByteString.Char8 (ByteString)
 import Data.Text (Text, pack)
 import qualified Network.HTTP.Client as Client
 import qualified Network.HTTP.Req as Req
+import Network.HTTP.Types (Status(..))
+
+import PyF (fmt)
 
 showHTTPException :: Req.HttpException
                   -> Text
@@ -20,5 +25,16 @@ showClientHttpException (Client.InvalidUrlException _ reason) = pack reason
 
 showExceptionContent :: Client.HttpExceptionContent
                      -> Text
+showExceptionContent (Client.StatusCodeException resp body) = showResponse resp body
 -- Catch all doing a simple and ugly show
 showExceptionContent exc = pack . show $ exc
+
+showResponse :: Client.Response ()
+             -> ByteString
+             -> Text
+showResponse resp body = [fmt|\
+HTTP call failed: {show status} - {show statusMsg}
+      {show body}\
+|]
+  where status = statusCode . Client.responseStatus $ resp
+        statusMsg = statusMessage . Client.responseStatus $ resp


### PR DESCRIPTION
Linked to #50

As discussed, first PR to just show the raw error to give the user some context

```bash
/Users/gbataille/Downloads/configuration-common.nix:1378:5: warning:
  Url could not be reached:
    Error:
      StatusCodeException (Response {responseStatus = Status {statusCode = 403, statusMessage = "Forbidden"}, responseVersion = HTTP/1.1, responseHeaders = [("Date","Sun, 09 Feb 2020 15:44:49 GMT"),("Content-Type","application/json; charset=utf-8"),("Transfer-Encoding","chunked"),("Server","GitHub.com"),("Status","403 Forbidden"),("X-RateLimit-Limit","60"),("X-RateLimit-Remaining","0"),("X-RateLimit-Reset","1581266229"),("X-GitHub-Media-Type","github.v3"),("Access-Control-Expose-Headers","ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type"),("Access-Control-Allow-Origin","*"),("Strict-Transport-Security","max-age=31536000; includeSubdomains; preload"),("X-Frame-Options","deny"),("X-Content-Type-Options","nosniff"),("X-XSS-Protection","1; mode=block"),("Referrer-Policy","origin-when-cross-origin, strict-origin-when-cross-origin"),("Content-Security-Policy","default-src 'none'"),("Vary","Accept-Encoding, Accept"),("Content-Encoding","gzip"),("X-GitHub-Request-Id","1191:0145:B63168:D7F036:5E4028F0")], responseBody = (), responseCookieJar = CJ {expose = []}, responseClose' = ResponseClose}) "{\"message\":\"API rate limit exceeded for 86.111.139.2. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)\",\"documentation_url\":\"https://developer.github.com/v3/#rate-limiting\"}"
    Requested URL:
      Url Https ("15" :| ["issues","servant-ekg","haskell-servant","repos","api.github.com"])
  : https://github.com/haskell-servant/servant-ekg/issues/15
```