### PR TITLE
Introducing MonadKrank

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -3,7 +3,9 @@
 {-# LANGUAGE ViewPatterns #-}
 
 import Control.Applicative (optional)
+import Control.Monad.Reader
 import qualified Data.Map as Map
+import Data.Semigroup ((<>))
 import qualified Data.Text as Text
 import Krank
 import Krank.Types
@@ -42,12 +44,10 @@ gitlabKeyToParse :: Opt.Parser (Map.Map GitlabHost GitlabKey)
 gitlabKeyToParse =
   Map.fromList
     <$> many
-      ( Opt.option
-          parseGitlabKey
-          ( Opt.long "issuetracker-gitlabhost"
-              <> Opt.metavar "HOST=PERSONAL_GITLAB_KEY"
-              <> Opt.help "A couple of gitlab host and developer key to allow reaching private gitlab repo for the IssueTracker checker. Can be specified multiple times."
-          )
+      ( Opt.option parseGitlabKey $
+          Opt.long "issuetracker-gitlabhost"
+            <> Opt.metavar "HOST=PERSONAL_GITLAB_KEY"
+            <> Opt.help "A couple of gitlab host and developer key to allow reaching private gitlab repo for the IssueTracker checker. Can be specified multiple times."
       )
 
 noColorParse :: Opt.Parser Bool
@@ -89,4 +89,4 @@ main = do
         (krankConfig config)
           { useColors = useColors (krankConfig config) && canUseColor
           }
-  runKrank (codeFilePaths config) kConfig
+  runReaderT (unKrank $ runKrank (codeFilePaths config)) kConfig

--- a/default.nix
+++ b/default.nix
@@ -57,6 +57,17 @@ rec {
   mkdir $out
   '';
 
+  hlint-fix = mkShell {
+    nativeBuildInputs = [haskellPackages.hlint git haskellPackages.apply-refact];
+    shellHook = ''
+      for file in $(git ls-files | grep '\.hs$')
+      do
+        hlint  --refactor --refactor-options='-i' $file
+      done
+      exit 0
+    '';
+  };
+
   ormolu-fix = mkShell {
     nativeBuildInputs = [haskellPackages.ormolu git];
     shellHook = ''

--- a/krank.cabal
+++ b/krank.cabal
@@ -55,6 +55,11 @@ test-suite krank-test
                        , pcre-heavy
                        , bytestring
                        , text
+                       , mtl
+                       , containers
+                       , req
+                       , aeson
+                       , safe-exceptions
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 
@@ -68,6 +73,7 @@ executable krank
                        , text
                        , PyF
                        , containers
+                       , mtl
   hs-source-dirs:      app
   default-language:    Haskell2010
   ghc-options:         -Wall -threaded -rtsopts

--- a/src/Krank.hs
+++ b/src/Krank.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -5,27 +7,31 @@
 
 module Krank
   ( runKrank,
+    Krank (..),
   )
 where
 
-import Control.Concurrent.Async.Lifted
+import Control.Concurrent.Async.Lifted (mapConcurrently)
 import Control.Exception.Safe
 import Control.Monad.Reader
 import qualified Data.ByteString
+import Data.Coerce
 import qualified Data.Text.IO as Text.IO
 import Krank.Checkers.Ignore (filterViolations)
 import qualified Krank.Checkers.IssueTracker as IT
 import Krank.Formatter
 import Krank.Types
+import qualified Network.HTTP.Req as Req
 import PyF
 import System.IO (stderr)
 
 processFile ::
+  MonadKrank m =>
   -- | the file to analyze
   FilePath ->
-  ReaderT KrankConfig IO [Violation]
+  m [Violation]
 processFile filePath = do
-  content <- liftIO $ Data.ByteString.readFile filePath
+  content <- krankReadFile filePath
   violations <- IT.checkText filePath content
   let filtered = filterViolations violations filePath content
   -- forcing 'violations' to WHNF forces more of the processing to happen inside the thread and
@@ -33,12 +39,45 @@ processFile filePath = do
   -- forcing to Normal Form (with deepseq) does not bring anymore improvement
   pure $! filtered
 
-runKrank :: [FilePath] -> KrankConfig -> IO ()
-runKrank paths options = flip runReaderT options $ do
-  KrankConfig {useColors} <- ask
-  res <- forConcurrently paths $ \path ->
+runKrank :: MonadKrank m => [FilePath] -> m ()
+runKrank paths = do
+  KrankConfig {useColors} <- krankAsks id
+  res <- krankForConcurrently paths $ \path ->
     (Right <$> processFile path)
       `catchAny` (\(SomeException e) -> pure $ Left [fmt|Error when processing {path}: {show e}|])
-  liftIO $ forM_ res $ \case
-    Left err -> Text.IO.hPutStrLn stderr err
-    Right violations -> Text.IO.putStr (foldMap (showViolation useColors) violations)
+  forM_ res $ \case
+    Left err -> krankPutStrLnStderr err
+    Right violations -> krankPutStr (foldMap (showViolation useColors) violations)
+
+-- | This just exists to avoid the orphan instance on MonadKrank
+newtype Krank t = Krank {unKrank :: ReaderT KrankConfig IO t}
+  deriving newtype (Functor, Applicative, Monad, MonadCatch, MonadThrow)
+
+-- | The real monad implementation for Krank
+instance MonadKrank Krank where
+
+  krankReadFile = Krank . liftIO . Data.ByteString.readFile
+
+  krankAsks = Krank . asks
+
+  krankPutStrLnStderr = Krank . liftIO . Text.IO.hPutStrLn stderr
+
+  krankPutStr = Krank . liftIO . Text.IO.putStr
+
+  -- Use threads for concurrency
+  krankMapConcurrently f l = Krank $ mapConcurrently (coerce . f) l
+
+  -- This implements a Req REST request
+  krankRunRESTRequest url headers = Krank
+    $ Req.runReq Req.defaultHttpConfig
+    $ do
+      r <-
+        Req.req
+          Req.GET
+          url
+          Req.NoReqBody
+          Req.jsonResponse
+          ( Req.header "User-Agent" "krank"
+              <> headers
+          )
+      pure $ Req.responseBody r


### PR DESCRIPTION
This deprecates #52 

This typeclass represents all the effect that krank needs to do in order
to function.

We have two instances:

- Krank, which is the normal implementation
- KrankTest, which is a pure API without side effect which can be used
in tests.

This also introduce two new tests in order to show the idea. More tests
will come.