### PR TITLE
Stack: use LTS 15 (ghc 8.8)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,8 +50,11 @@ jobs:
             - cci-demo-haskell-v1-{{ checksum "stack.yaml" }}
             - cci-demo-haskell-v1
       - run:
-          name: Build
+          name: Build 8.8
           command: stack test -j1
+      - run:
+          name: Build 8.6
+          command: stack --resolver lts-14.27 test -j1
       - save_cache:
           when: always
           name: Cache Dependencies

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.27
+resolver: lts-15.0
 
 packages:
 - .


### PR DESCRIPTION
We also keep LTS 14 (ghc 8.6) in the CI. Policy will be to have at least
2 versions of GHC in the CI.