### PR TITLE
Fail on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ foo.hs:67:11: error:
   now Closed: https://github.com/bazelbuild/bazel/issues/6313
 ```
 
+`krank` will fail (i.e. non-zero exit code) in case of any error.
+
 Here `krank` is telling us that our source code links to github
 issues which are now closed. Time to remove some workarounds now that upstream issues are fixed!
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -12,6 +12,7 @@ import qualified Options.Applicative as Opt
 import Options.Applicative ((<**>), many, some)
 import PyF (fmt)
 import System.Console.Pretty (supportsPretty)
+import System.Exit (exitFailure)
 import Text.Regex.PCRE.Heavy
 
 data KrankOpts
@@ -88,4 +89,5 @@ main = do
         (krankConfig config)
           { useColors = useColors (krankConfig config) && canUseColor
           }
-  runReaderT (unKrank $ runKrank (codeFilePaths config)) kConfig
+  success <- runReaderT (unKrank $ runKrank (codeFilePaths config)) kConfig
+  unless success exitFailure


### PR DESCRIPTION
`krank` now fails on failure.

- Any kind of failure.
- Unconditionally. I decided that if it fails in a shell under user supervision, that's fine. If it fails in CI, I prefer that it fails by default and that user recover from the failure using `|| true` instead of inserting yet another command line argument.
- Tests added.

It closes #31.