### PR TITLE
50 handle rate limit errors

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -18,6 +18,7 @@ rec {
     "tests/Test"
     "tests/Test/Krank"
     "tests/Test/Krank/Checkers"
+    "tests/Test/Utils"
     "docs"
     "docs/Checkers"
     "LICENSE"

--- a/krank.cabal
+++ b/krank.cabal
@@ -21,9 +21,10 @@ library
                        Krank.Checkers.IssueTracker
                        Krank.Formatter
                        Krank.Types
-                       Utils.Req
+                       Utils.Display
                        Utils.Github
                        Utils.Gitlab
+                       Utils.Req
 
   build-depends:       base >= 4.9
                        , PyF >= 0.8.1.0

--- a/krank.cabal
+++ b/krank.cabal
@@ -21,25 +21,27 @@ library
                        Krank.Checkers.IssueTracker
                        Krank.Formatter
                        Krank.Types
-  other-modules:       Utils.Req
+                       Utils.Req
+                       Utils.Github
+                       Utils.Gitlab
 
   build-depends:       base >= 4.9
+                       , PyF >= 0.8.1.0
                        , aeson >= 1.4.4
+                       , bytestring
+                       , containers
                        , http-client >= 0.6
                        , http-types >= 0.12
-                       , PyF >= 0.8.1.0
+                       , lifted-async
+                       , mtl
+                       , pcre-heavy
+                       , pretty-terminal
                        , req >= 2.1.0
+                       , safe-exceptions
                        , text >= 1.2.3
                        , unordered-containers >= 0.2.10
-                       , pcre-heavy
-                       , mtl
-                       , safe-exceptions
-                       , pretty-terminal
-                       , bytestring
-                       , lifted-async
-                       , containers
   hs-source-dirs:      src
-  ghc-options: -Wall
+  ghc-options:         -Wall
   default-language:    Haskell2010
 
 test-suite krank-test
@@ -47,19 +49,24 @@ test-suite krank-test
   hs-source-dirs:      tests
   main-is:             Spec.hs
   other-modules:       Test.Krank.Checkers.IssueTrackerSpec
+                       Test.Utils.GithubSpec
   build-tools:
   build-depends:       base
-                       , hspec >= 2.7
                        , PyF >= 0.8.1.0
-                       , krank
-                       , pcre-heavy
-                       , bytestring
-                       , text
-                       , mtl
-                       , containers
-                       , req
                        , aeson
+                       , bytestring
+                       , containers
+                       , hspec >= 2.7
+                       , http-client >= 0.6
+                       , http-types >= 0.12
+                       , krank
+                       , mtl
+                       , pcre-heavy
+                       , req
+                       , req >= 2.1.0
                        , safe-exceptions
+                       , text
+                       , unordered-containers >= 0.2.10
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
   default-language:    Haskell2010
 

--- a/src/Krank/Checkers/IssueTracker.hs
+++ b/src/Krank/Checkers/IssueTracker.hs
@@ -144,15 +144,7 @@ httpExcHandler ::
   Req.HttpException ->
   m Value
 httpExcHandler gitServer exc =
-  pure . AesonT.object $
-    [ ( "error",
-        AesonT.String . pack $
-          [fmt|
-    Error:
-      {(showGitServerException gitServer exc)}
-  |]
-      )
-    ]
+  pure . AesonT.object $ [("error", AesonT.String . pack $ [fmt|{(showGitServerException gitServer exc)}|])]
 
 showGitServerException ::
   GitServer ->
@@ -218,7 +210,7 @@ issueToMessage i = case issueStatus i of
   Closed -> [fmt|now Closed|]
 
 issuePrintUrl :: GitIssue -> Text
-issuePrintUrl GitIssue {owner, repo, server, issueNum} = [fmt|https://{serverDomain server}/{owner}/{repo}/issues/{issueNum}|]
+issuePrintUrl GitIssue {owner, repo, server, issueNum} = [fmt|IssueTracker check for https://{serverDomain server}/{owner}/{repo}/issues/{issueNum}|]
 
 checkText ::
   MonadKrank m =>
@@ -249,7 +241,7 @@ checkText path t = do
       Violation
         { checker = issuePrintUrl . unLocalized $ issue,
           level = Warning,
-          message = "Url could not be reached: " <> err,
+          message = "Error when calling the API:\n" <> err,
           location = getLocation (issue :: Localized GitIssue)
         }
     f (Right issue) =

--- a/src/Krank/Formatter.hs
+++ b/src/Krank/Formatter.hs
@@ -12,6 +12,7 @@ import Data.Text (Text)
 import Krank.Types
 import PyF (fmt)
 import System.Console.Pretty
+import Utils.Display (indent)
 
 showViolation ::
   Bool ->
@@ -20,7 +21,8 @@ showViolation ::
 showViolation useColors Violation {checker, location, level, message} =
   [fmt|
 {showSourcePos location}: {showViolationLevel useColors level}:
-  {message}: {checker}
+{indent 2 checker}
+{indent 4 message}
 |]
 
 showViolationLevel :: Bool -> ViolationLevel -> String

--- a/src/Utils/Display.hs
+++ b/src/Utils/Display.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Utils.Display
+  ( indent,
+  )
+where
+
+import qualified Data.Text as Text
+import PyF (fmt)
+
+-- | indent the text given by a certain number of space character
+-- If the text given contains multiple lines, all the lines but the first will be prefixed by the
+-- continuation character '|'
+indent :: Int -> Text.Text -> Text.Text
+indent nbSpaces text = indentedText
+  where
+    (firstLine : nextLines) = Text.splitOn "\n" text
+    prefixedLines = map (\a -> [fmt|| {a}|]) nextLines
+    indentedLines = map (\a -> [fmt|{take nbSpaces $ repeat ' '}{a}|]) (firstLine : prefixedLines)
+    indentedText = Text.intercalate "\n" indentedLines

--- a/src/Utils/Display.hs
+++ b/src/Utils/Display.hs
@@ -17,5 +17,5 @@ indent nbSpaces text = indentedText
   where
     (firstLine : nextLines) = Text.splitOn "\n" text
     prefixedLines = map (\a -> [fmt|| {a}|]) nextLines
-    indentedLines = map (\a -> [fmt|{take nbSpaces $ repeat ' '}{a}|]) (firstLine : prefixedLines)
+    indentedLines = map (\a -> [fmt|{replicate nbSpaces ' '}{a}|]) (firstLine : prefixedLines)
     indentedText = Text.intercalate "\n" indentedLines

--- a/src/Utils/Github.hs
+++ b/src/Utils/Github.hs
@@ -1,0 +1,78 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Utils.Github
+  ( showGithubException,
+    githubAPILimitErrorText,
+  )
+where
+
+import Data.Aeson (FromJSON, ToJSON, decode)
+import Data.ByteString.Char8 (ByteString)
+import Data.ByteString.Lazy (fromStrict)
+import Data.Text (Text, isPrefixOf)
+import GHC.Generics (Generic)
+import qualified Network.HTTP.Client as Client
+import qualified Network.HTTP.Req as Req
+import PyF (fmt)
+import Utils.Req (showHTTPException, showRawResponse)
+
+{- HLint ignore "Use newtype instead of data" -}
+
+-- | Represents a typical Github Error serialized as JSON like so:
+--
+-- @
+-- {
+--    "message": "the error reason"
+-- }
+-- @
+data GithubError
+  = GithubError
+      { message :: Text
+      }
+  deriving (Generic, Show, FromJSON, ToJSON)
+
+-- | Uses the helper to show generic HTTP issues and provides a specific handler for Github
+-- "business" exceptions
+showGithubException ::
+  Req.HttpException ->
+  Text
+showGithubException = showHTTPException handleGithubException
+
+handleGithubException ::
+  Client.Response () ->
+  ByteString ->
+  Text
+handleGithubException resp body =
+  case err of
+    Just githubError -> showRawGithubMessage githubError
+    Nothing -> showRawResponse resp body
+  where
+    err = decode $ fromStrict body :: Maybe GithubError
+
+showRawGithubMessage ::
+  GithubError ->
+  Text
+showRawGithubMessage err
+  | isApiRateLimitError msg = githubAPILimitErrorText
+  | otherwise = [fmt|From Github: {msg}|]
+  where
+    msg = message err
+
+githubAPILimitErrorText :: Text
+githubAPILimitErrorText =
+  [fmt|\
+Github API Rate limit exceeded.
+| You might want to provide a github API key with the --issuetracker-githubkey option.
+| See https://github.com/guibou/krank/blob/master/docs/Checkers/IssueTracker.md#api-rate-limitation
+|]
+
+apiRateLimitPrefix :: Text
+apiRateLimitPrefix = "API rate limit exceeded"
+
+isApiRateLimitError ::
+  Text ->
+  Bool
+isApiRateLimitError = isPrefixOf apiRateLimitPrefix

--- a/src/Utils/Github.hs
+++ b/src/Utils/Github.hs
@@ -65,9 +65,8 @@ githubAPILimitErrorText :: Text
 githubAPILimitErrorText =
   [fmt|\
 Github API Rate limit exceeded.
-| You might want to provide a github API key with the --issuetracker-githubkey option.
-| See https://github.com/guibou/krank/blob/master/docs/Checkers/IssueTracker.md#api-rate-limitation
-|]
+You might want to provide a github API key with the --issuetracker-githubkey option.
+See https://github.com/guibou/krank/blob/master/docs/Checkers/IssueTracker.md#api-rate-limitation|]
 
 apiRateLimitPrefix :: Text
 apiRateLimitPrefix = "API rate limit exceeded"

--- a/src/Utils/Gitlab.hs
+++ b/src/Utils/Gitlab.hs
@@ -1,0 +1,13 @@
+module Utils.Gitlab
+  ( showGitlabException,
+  )
+where
+
+import Data.Text (Text)
+import qualified Network.HTTP.Req as Req
+import Utils.Req (showHTTPException, showRawResponse)
+
+showGitlabException ::
+  Req.HttpException ->
+  Text
+showGitlabException = showHTTPException showRawResponse

--- a/src/Utils/Req.hs
+++ b/src/Utils/Req.hs
@@ -1,8 +1,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 
+-- |
+-- Module      : Utils.Req
+-- Description : Utilities to handle Network.Req HTTP exceptions
 module Utils.Req
   ( showHTTPException,
+    showRawResponse,
   )
 where
 
@@ -14,29 +18,35 @@ import Network.HTTP.Types (Status (..))
 import PyF (fmt)
 
 showHTTPException ::
+  -- | A function that accepts a StatusCodeException details and returns the appropriate text
+  (Client.Response () -> ByteString -> Text) ->
   Req.HttpException ->
   Text
-showHTTPException (Req.VanillaHttpException clientHttpException) = showClientHttpException clientHttpException
-showHTTPException (Req.JsonHttpException exc) = pack exc
+showHTTPException businessExcHandler (Req.VanillaHttpException clientHttpException) = showClientHttpException businessExcHandler clientHttpException
+showHTTPException _ (Req.JsonHttpException exc) = pack exc
 
 showClientHttpException ::
+  -- | A function that accepts a StatusCodeException details and returns the appropriate text
+  (Client.Response () -> ByteString -> Text) ->
   Client.HttpException ->
   Text
-showClientHttpException (Client.HttpExceptionRequest _ excContent) = showExceptionContent excContent
-showClientHttpException (Client.InvalidUrlException _ reason) = pack reason
+showClientHttpException businessExcHandler (Client.HttpExceptionRequest _ excContent) = showExceptionContent businessExcHandler excContent
+showClientHttpException _ (Client.InvalidUrlException _ reason) = pack reason
 
 showExceptionContent ::
+  -- | A function that accepts a StatusCodeException details and returns the appropriate text
+  (Client.Response () -> ByteString -> Text) ->
   Client.HttpExceptionContent ->
   Text
-showExceptionContent (Client.StatusCodeException resp body) = showResponse resp body
+showExceptionContent businessExcHandler (Client.StatusCodeException resp body) = businessExcHandler resp body
 -- Catch all doing a simple and ugly show
-showExceptionContent exc = pack . show $ exc
+showExceptionContent _ exc = pack . show $ exc
 
-showResponse ::
+showRawResponse ::
   Client.Response () ->
   ByteString ->
   Text
-showResponse resp body =
+showRawResponse resp body =
   [fmt|\
 HTTP call failed: {show status} - {show statusMsg}
       {show body}\

--- a/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
+++ b/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
@@ -147,7 +147,7 @@ spec = do
     let Right res = runReaderT (runWriterT (unTestKrank $ runKrank ["foo", "bar"])) (env, config)
     res
       `shouldBe` ( (),
-                   ( ["\nfoo:1:12: error:\n  now Closed: https://github.com/foo/bar/issues/10\n\nfoo:2:1: info:\n  still Open: https://github.com/foo/bar/issues/11\n"] :: [Text],
+                   ( ["\nfoo:1:12: error:\n  IssueTracker check for https://github.com/foo/bar/issues/10\n    now Closed\n\nfoo:2:1: info:\n  IssueTracker check for https://github.com/foo/bar/issues/11\n    still Open\n"] :: [Text],
                      [ "Error when processing bar: user error (file not found)"
                      ] ::
                        [Text]

--- a/tests/Test/Utils/GithubSpec.hs
+++ b/tests/Test/Utils/GithubSpec.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+-- Leaving unnecessary do because
+--  * they improve readability
+--  * if you add a context, or an it, it'll still compile, without remembering that there was no do
+--  before because at the time there was a single function inside
+--  * without those do, ormolu does some formatting that looks crazy to me
+{- Hlint ignore "Redundant do" -}
+
+module Test.Utils.GithubSpec
+  ( spec,
+  )
+where
+
+import Data.Aeson (Value (..), encode)
+import Data.ByteString.Lazy (ByteString, toStrict)
+import Data.HashMap.Strict (singleton)
+import Data.Text (Text, isInfixOf, isPrefixOf)
+import Network.HTTP.Client (HttpException (..), HttpExceptionContent (..), createCookieJar, defaultRequest)
+import Network.HTTP.Client.Internal (Response (..), ResponseClose (..))
+import Network.HTTP.Req (HttpException (..))
+import Network.HTTP.Types (status400)
+import Network.HTTP.Types.Version (http11)
+import Test.Hspec
+import Utils.Github (githubAPILimitErrorText, showGithubException)
+import Utils.Req (showHTTPException, showRawResponse)
+
+spec :: Spec
+spec = do
+  describe "Utils.Github" $ do
+    context "Github \"business\" errors, 4xx status code, \"message\" structure" $ do
+      it "Display the content of the error message, deserialized from the JSON" $ do
+        let errorMsg = "some_error"
+        let body = mkGithubErrorBody errorMsg
+        let errorText = getErrorText body
+        ("From Github:" `isPrefixOf` errorText) `shouldBe` True
+        (errorMsg `isInfixOf` errorText) `shouldBe` True
+    context "Github API Rate Limit error" $ do
+      it "Displays the specific message for API errors" $ do
+        let errorMsg = "API rate limit exceeded for 86.111.137.132. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)"
+        let body = mkGithubErrorBody errorMsg
+        let errorText = getErrorText body
+        (githubAPILimitErrorText `isInfixOf` errorText) `shouldBe` True
+    context "Non-JSON response exception" $ do
+      it "Shows the raw exception, through the generic helper" $ do
+        let exception = JsonHttpException "JSON decoding failed"
+        showGithubException exception `shouldBe` showHTTPException showRawResponse exception
+    context "Invalid URL exception" $ do
+      it "Shows the raw exception, through the generic helper" $ do
+        let exception = VanillaHttpException $ InvalidUrlException "file://foo" "bar"
+        showGithubException exception `shouldBe` showHTTPException showRawResponse exception
+    context "otherHttpException" $ do
+      it "Shows the raw exception, through the generic helper" $ do
+        let exception = VanillaHttpException $ HttpExceptionRequest defaultRequest ConnectionTimeout
+        showGithubException exception `shouldBe` showHTTPException showRawResponse exception
+
+dummyResponse :: Response ()
+dummyResponse = Response status400 http11 [] () (createCookieJar []) (ResponseClose $ pure ())
+
+-- | From a raw error message to a JSON formatted github error
+mkGithubErrorBody :: Text -> ByteString
+mkGithubErrorBody msg = encode $ Object $ singleton "message" (String msg)
+
+-- | From a raw JSON response body to the interpreted displayed text
+getErrorText :: ByteString -> Text
+getErrorText body = showGithubException $ VanillaHttpException $ HttpExceptionRequest defaultRequest (StatusCodeException dummyResponse (toStrict body))


### PR DESCRIPTION
Contributes to #50 

Let's start with that to validate the "structure" of the specific error handling and we'll add some from there.

So the `IssueTracker` knows whether which GIT service we are interacting with. It therefore uses a specific handler for each type of server.

This handler makes use of a generic `Utils.Req` library that allows for the unpacking for the HTTP Exception and the handling of non service specific errors (like a connection timeout for example)