### PR TITLE
refactor: better error message display

### DIFF
--- a/krank.cabal
+++ b/krank.cabal
@@ -21,9 +21,10 @@ library
                        Krank.Checkers.IssueTracker
                        Krank.Formatter
                        Krank.Types
-                       Utils.Req
+                       Utils.Display
                        Utils.Github
                        Utils.Gitlab
+                       Utils.Req
 
   build-depends:       base >= 4.9
                        , PyF >= 0.8.1.0

--- a/src/Krank/Checkers/IssueTracker.hs
+++ b/src/Krank/Checkers/IssueTracker.hs
@@ -144,15 +144,7 @@ httpExcHandler ::
   Req.HttpException ->
   m Value
 httpExcHandler gitServer exc =
-  pure . AesonT.object $
-    [ ( "error",
-        AesonT.String . pack $
-          [fmt|
-    Error:
-      {(showGitServerException gitServer exc)}
-  |]
-      )
-    ]
+  pure . AesonT.object $ [("error", AesonT.String . pack $ [fmt|{(showGitServerException gitServer exc)}|])]
 
 showGitServerException ::
   GitServer ->
@@ -218,7 +210,7 @@ issueToMessage i = case issueStatus i of
   Closed -> [fmt|now Closed|]
 
 issuePrintUrl :: GitIssue -> Text
-issuePrintUrl GitIssue {owner, repo, server, issueNum} = [fmt|https://{serverDomain server}/{owner}/{repo}/issues/{issueNum}|]
+issuePrintUrl GitIssue {owner, repo, server, issueNum} = [fmt|IssueTracker check for https://{serverDomain server}/{owner}/{repo}/issues/{issueNum}|]
 
 checkText ::
   MonadKrank m =>
@@ -249,7 +241,7 @@ checkText path t = do
       Violation
         { checker = issuePrintUrl . unLocalized $ issue,
           level = Warning,
-          message = "Url could not be reached: " <> err,
+          message = "Error when calling the API:\n" <> err,
           location = getLocation (issue :: Localized GitIssue)
         }
     f (Right issue) =

--- a/src/Krank/Formatter.hs
+++ b/src/Krank/Formatter.hs
@@ -12,6 +12,7 @@ import Data.Text (Text)
 import Krank.Types
 import PyF (fmt)
 import System.Console.Pretty
+import Utils.Display (indent)
 
 showViolation ::
   Bool ->
@@ -20,7 +21,8 @@ showViolation ::
 showViolation useColors Violation {checker, location, level, message} =
   [fmt|
 {showSourcePos location}: {showViolationLevel useColors level}:
-  {message}: {checker}
+{indent 2 checker}
+{indent 4 message}
 |]
 
 showViolationLevel :: Bool -> ViolationLevel -> String

--- a/src/Utils/Display.hs
+++ b/src/Utils/Display.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Utils.Display
+  ( indent,
+  )
+where
+
+import qualified Data.Text as Text
+import PyF (fmt)
+
+-- | indent the text given by a certain number of space character
+-- If the text given contains multiple lines, all the lines but the first will be prefixed by the
+-- continuation character '|'
+indent :: Int -> Text.Text -> Text.Text
+indent nbSpaces text = indentedText
+  where
+    (firstLine : nextLines) = Text.splitOn "\n" text
+    prefixedLines = map (\a -> [fmt|| {a}|]) nextLines
+    indentedLines = map (\a -> [fmt|{take nbSpaces $ repeat ' '}{a}|]) (firstLine : prefixedLines)
+    indentedText = Text.intercalate "\n" indentedLines

--- a/src/Utils/Github.hs
+++ b/src/Utils/Github.hs
@@ -65,9 +65,8 @@ githubAPILimitErrorText :: Text
 githubAPILimitErrorText =
   [fmt|\
 Github API Rate limit exceeded.
-| You might want to provide a github API key with the --issuetracker-githubkey option.
-| See https://github.com/guibou/krank/blob/master/docs/Checkers/IssueTracker.md#api-rate-limitation
-|]
+You might want to provide a github API key with the --issuetracker-githubkey option.
+See https://github.com/guibou/krank/blob/master/docs/Checkers/IssueTracker.md#api-rate-limitation|]
 
 apiRateLimitPrefix :: Text
 apiRateLimitPrefix = "API rate limit exceeded"

--- a/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
+++ b/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
@@ -147,7 +147,7 @@ spec = do
     let Right res = runReaderT (runWriterT (unTestKrank $ runKrank ["foo", "bar"])) (env, config)
     res
       `shouldBe` ( (),
-                   ( ["\nfoo:1:12: error:\n  now Closed: https://github.com/foo/bar/issues/10\n\nfoo:2:1: info:\n  still Open: https://github.com/foo/bar/issues/11\n"] :: [Text],
+                   ( ["\nfoo:1:12: error:\n  IssueTracker check for https://github.com/foo/bar/issues/10\n    now Closed\n\nfoo:2:1: info:\n  IssueTracker check for https://github.com/foo/bar/issues/11\n    still Open\n"] :: [Text],
                      [ "Error when processing bar: user error (file not found)"
                      ] ::
                        [Text]


### PR DESCRIPTION
Moving from 
<img width="701" alt="Screenshot 2020-03-08 at 11 05 19" src="https://user-images.githubusercontent.com/1113065/76160727-d9dfce80-612c-11ea-838a-3cff5cd2ec06.png">
to
<img width="734" alt="Screenshot 2020-03-08 at 11 12 14" src="https://user-images.githubusercontent.com/1113065/76160824-b1a49f80-612d-11ea-9dcc-f113fe0f5e83.png">

* First is the file and the violation position
* Second, indented, is the checker "header"/"title" message
* Third, further indented, is the violation text

Same on non errored checker

from
<img width="397" alt="Screenshot 2020-03-08 at 11 14 04" src="https://user-images.githubusercontent.com/1113065/76160853-fa5c5880-612d-11ea-9da3-ff5eec39b7ea.png">
to
<img width="473" alt="Screenshot 2020-03-08 at 11 13 23" src="https://user-images.githubusercontent.com/1113065/76160843-e284d480-612d-11ea-8734-89817668d59d.png">
