### PR TITLE
Clean hlint

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,6 @@
+# Leaving unnecessary do because
+#  * they improve readability
+#  * if you add a context, or an it, it'll still compile, without remembering that there was no do
+#  before because at the time there was a single function inside
+#  * without those do, ormolu does some formatting that looks crazy to me
+- ignore: {name: "Redundant do"}

--- a/default.nix
+++ b/default.nix
@@ -22,6 +22,7 @@ rec {
     "docs"
     "docs/Checkers"
     "LICENSE"
+    ".hlint.yaml"
   ];
 
   # buildFromSdist ensures that the build will work on hackage

--- a/src/Utils/Github.hs
+++ b/src/Utils/Github.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 
@@ -32,7 +33,8 @@ newtype GithubError
   = GithubError
       { message :: Text
       }
-  deriving (Generic, Show, FromJSON, ToJSON)
+  deriving stock (Generic, Show)
+  deriving anyclass (FromJSON, ToJSON)
 
 -- | Uses the helper to show generic HTTP issues and provides a specific handler for Github
 -- "business" exceptions

--- a/src/Utils/Github.hs
+++ b/src/Utils/Github.hs
@@ -21,8 +21,6 @@ import Network.HTTP.Types (Status (..))
 import PyF (fmt)
 import Utils.Req (showHTTPException, showRawResponse)
 
-{- HLint ignore "Use newtype instead of data" -}
-
 -- | Represents a typical Github Error serialized as JSON like so:
 --
 -- @
@@ -30,7 +28,7 @@ import Utils.Req (showHTTPException, showRawResponse)
 --    "message": "the error reason"
 -- }
 -- @
-data GithubError
+newtype GithubError
   = GithubError
       { message :: Text
       }

--- a/src/Utils/Gitlab.hs
+++ b/src/Utils/Gitlab.hs
@@ -21,8 +21,6 @@ import Network.HTTP.Types (Status (..))
 import PyF (fmt)
 import Utils.Req (showHTTPException, showRawResponse)
 
-{- HLint ignore "Use newtype instead of data" -}
-
 -- | Represents a typical Gitlab Error serialized as JSON like so:
 --
 -- @
@@ -30,7 +28,7 @@ import Utils.Req (showHTTPException, showRawResponse)
 --    "message": "the error reason"
 -- }
 -- @
-data GitlabError
+newtype GitlabError
   = GitlabError
       { message :: Text
       }

--- a/src/Utils/Gitlab.hs
+++ b/src/Utils/Gitlab.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 
@@ -32,7 +33,8 @@ newtype GitlabError
   = GitlabError
       { message :: Text
       }
-  deriving (Generic, Show, FromJSON, ToJSON)
+  deriving stock (Generic, Show)
+  deriving anyclass (FromJSON, ToJSON)
 
 -- | Uses the helper to show generic HTTP issues and provides a specific handler for Gitlab
 -- "business" exceptions

--- a/tests/Test/Utils/GithubSpec.hs
+++ b/tests/Test/Utils/GithubSpec.hs
@@ -1,13 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
--- Leaving unnecessary do because
---  * they improve readability
---  * if you add a context, or an it, it'll still compile, without remembering that there was no do
---  before because at the time there was a single function inside
---  * without those do, ormolu does some formatting that looks crazy to me
-{- Hlint ignore "Redundant do" -}
-
 module Test.Utils.GithubSpec
   ( spec,
   )


### PR DESCRIPTION
It cleans a bit of the hlint special cases in two ways:

- Move redundant do ignore in a global hlint file. I do really agree that this warning is painful, so better ignoring it for the whole project.
- I applied the `data` -> `newtype` hint and did a few changes to ensure that 