### PR TITLE
Fix issue 76 split many url on a line

### DIFF
--- a/krank.cabal
+++ b/krank.cabal
@@ -1,10 +1,10 @@
-cabal-version:       >=1.10
+cabal-version:       2.2
 name:                krank
 version:             0.2.0
 synopsis: Krank checks your code source comments for important markers
 -- description:
 bug-reports: https://github.com/guibou/krank/issues
-license: BSD3
+license: BSD-3-Clause
 license-file:        LICENSE
 author:              Guillaume Bouchard
 maintainer:          guillaum.bouchard@gmail.com
@@ -15,17 +15,7 @@ description: Comments are part of our code and are not usually tested correctly.
 build-type:          Simple
 extra-source-files:  CHANGELOG.md, README.md HACKING.md docs/Checkers/IssueTracker.md
 
-library
-  exposed-modules:     Krank
-                       Krank.Checkers.Ignore
-                       Krank.Checkers.IssueTracker
-                       Krank.Formatter
-                       Krank.Types
-                       Utils.Display
-                       Utils.Github
-                       Utils.Gitlab
-                       Utils.Req
-
+common shared-library
   build-depends:       base >= 4.9
                        , PyF >= 0.8.1.0
                        , aeson >= 1.4.4
@@ -42,36 +32,43 @@ library
                        , text >= 1.2.3
                        , unordered-containers >= 0.2.10
   hs-source-dirs:      src
+
   ghc-options:         -Wall
   default-language:    Haskell2010
 
+library
+  import: shared-library
+  exposed-modules:     Krank
+                       Krank.Checkers.Ignore
+                       Krank.Checkers.IssueTracker
+                       Krank.Formatter
+                       Krank.Types
+                       Utils.Display
+                       Utils.Github
+                       Utils.Gitlab
+                       Utils.Req
+
 test-suite krank-test
+  import: shared-library
+
   type:                exitcode-stdio-1.0
-  hs-source-dirs:      tests
   main-is:             Spec.hs
+
+  hs-source-dirs:      tests
   other-modules:       Test.Krank.Checkers.IssueTrackerSpec
                        Test.Utils.GithubSpec
                        Test.Utils.GitlabSpec
-  build-tools:
-  build-depends:       base >= 4.9 && <= 5.0
-                       , PyF >= 0.8.1.0
-                       , aeson
-                       , bytestring
-                       , containers
-                       , hspec >= 2.7
-                       , hspec-expectations
-                       , http-client >= 0.6
-                       , http-types >= 0.12
-                       , krank
-                       , mtl
-                       , pcre-heavy
-                       , req
-                       , req >= 2.1.0
-                       , safe-exceptions
-                       , text
-                       , unordered-containers >= 0.2.10
-  ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
-  default-language:    Haskell2010
+                       Krank
+                       Krank.Checkers.Ignore
+                       Krank.Checkers.IssueTracker
+                       Krank.Formatter
+                       Krank.Types
+                       Utils.Display
+                       Utils.Github
+                       Utils.Gitlab
+  build-depends: hspec >= 2.7
+               , hspec-expectations
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
 
 executable krank
   main-is:             Main.hs

--- a/src/Krank/Checkers/IssueTracker.hs
+++ b/src/Krank/Checkers/IssueTracker.hs
@@ -65,7 +65,7 @@ serverDomain (Gitlab (GitlabHost h)) = h
 gitRepoRe :: RE.Regex
 -- NOTE: \b at the beginning is really import for performances
 -- because it dramatically reduces the number of backtracks
-gitRepoRe = [RE.re|\b(?>https?://)?(?>www\.)?([^/ ]+)/(.*)/([^-][^/]*)(?>/-)?/issues/([0-9]+)|]
+gitRepoRe = [RE.re|\b(?>https?://)?(?>www\.)?([^/ ]+)/([^ ]+)/([^- ][^/ ]*)(?>/-)?/issues/([0-9]+)|]
 
 -- | Extract all issues on one line and returns a list of the raw text associated with an issue
 extractIssuesOnALine :: ByteString -> [(Int, GitIssue)]

--- a/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
+++ b/tests/Test/Krank/Checkers/IssueTrackerSpec.hs
@@ -216,3 +216,17 @@ spec = do
                          [Text]
                      )
                    )
+  describe "it parses when there is two url on the same line" $ do
+    it "works correctly with only one in second position" $ do
+      extractIssues "foo" "https://ip.tyk.nu https://github.com/x/x/issues/32"
+        `shouldBe` [ Localized (SourcePos "foo" 1 19) (GitIssue Github "x" "x" 32)
+                   ]
+    it "works correctly with only one in first position" $ do
+      extractIssues "foo" "foo bar baz https://github.com/x/x/issues/32 https://ip.tyk.nu"
+        `shouldBe` [ Localized (SourcePos "foo" 1 13) (GitIssue Github "x" "x" 32)
+                   ]
+    it "works correctly with two correct url" $ do
+      extractIssues "foo" "foo gitlab.com/foo/br/issues/10 https://github.com/x/x/issues/32 https://ip.tyk.nu"
+        `shouldBe` [ Localized (SourcePos "foo" 1 5) (GitIssue (Gitlab (GitlabHost "gitlab.com")) "foo" "br" 10),
+                     Localized (SourcePos "foo" 1 33) (GitIssue Github "x" "x" 32)
+                   ]


### PR DESCRIPTION
This closes #76.

It also includes (yes, that's bad) some refactor of `krank.cabal` to be able to run `cabal repl tests` and use `:r` to reload the library. This is a rather surprising behavior, but you need to reload the repl to observe the changes in the library.