### PR TITLE
feat: display program version

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -14,6 +14,7 @@ import PyF (fmt)
 import System.Console.Pretty (supportsPretty)
 import System.Exit (exitFailure)
 import Text.Regex.PCRE.Heavy
+import Version (displayVersion)
 
 data KrankOpts
   = KrankOpts
@@ -58,6 +59,14 @@ noColorParse =
           <> Opt.help "Disable colored outputs"
       )
 
+versionParse :: Opt.Parser (a -> a)
+versionParse =
+  Opt.infoOption
+    displayVersion
+    ( Opt.long "version"
+        <> Opt.help "Displays the version of the program"
+    )
+
 optionsParser :: Opt.Parser KrankOpts
 optionsParser =
   KrankOpts
@@ -75,7 +84,7 @@ optionsParser =
 opts :: Opt.ParserInfo KrankOpts
 opts =
   Opt.info
-    (optionsParser <**> Opt.helper)
+    (optionsParser <**> Opt.helper <**> versionParse)
     ( Opt.fullDesc
         <> Opt.progDesc "Checks the comments in FILES"
         <> Opt.header "krank - a comment linter / analytics tool"
@@ -84,7 +93,7 @@ opts =
 main :: IO ()
 main = do
   canUseColor <- supportsPretty
-  config <- Opt.execParser opts
+  config <- Opt.customExecParser (Opt.prefs Opt.showHelpOnError) opts
   let kConfig =
         (krankConfig config)
           { useColors = useColors (krankConfig config) && canUseColor

--- a/krank.cabal
+++ b/krank.cabal
@@ -47,6 +47,8 @@ library
                        Utils.Github
                        Utils.Gitlab
                        Utils.Req
+                       Version
+  other-modules:       Paths_krank
 
 test-suite krank-test
   import: shared-library

--- a/src/Version.hs
+++ b/src/Version.hs
@@ -1,0 +1,16 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Version
+  ( displayVersion,
+  )
+where
+
+import Data.Version (showVersion)
+import Paths_krank (version)
+import PyF (fmt)
+
+getVersion :: String
+getVersion = showVersion version
+
+displayVersion :: String
+displayVersion = [fmt|Krank {getVersion}|]


### PR DESCRIPTION
Fixes #81

Took me a while but I think I have found a clean way to do that, both with options-applicative to have an option that "stops the program", like `--help` and with cabal giving me the version number (https://www.haskell.org/cabal/users-guide/developing-packages.html#accessing-data-files-from-package-code)