### PR TITLE
Qualify HashMap import

### DIFF
--- a/src/Krank/Checkers/Ignore.hs
+++ b/src/Krank/Checkers/Ignore.hs
@@ -9,7 +9,7 @@ where
 
 import qualified Data.ByteString.Char8 as ByteString
 import Data.ByteString.Char8 (ByteString)
-import Data.HashMap.Strict as HashM
+import qualified Data.HashMap.Strict as HashM
 import qualified Data.List as DataL
 import Krank.Types
 import PyF (fmt)


### PR DESCRIPTION
This closes #84. Build was failing because Data.HashMap.Strict exports
`fold` since 0.2.11.0.

Tested with `stack --resolver nightly-2020-06-29 build`