### PR TITLE
Add support (and a requirement) for aeson-2.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v12
-    - uses: cachix/cachix-action@v8
+    - uses: cachix/cachix-action@v10
       with:
         name: guibou
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: cachix/install-nix-action@v12
-    - uses: cachix/cachix-action@v8
+    - uses: cachix/cachix-action@v10
       with:
         name: guibou
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,5 +31,5 @@ jobs:
       run: sudo apt-get install haskell-stack
 
     # Build stack
-    - name: Stack 8.10
+    - name: Stack 9.0
       run: stack --resolver lts-19.6 test

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,6 +32,4 @@ jobs:
 
     # Build stack
     - name: Stack 8.10
-      run: stack --resolver lts-17.1 test
-    - name: Stack 8.8
-      run: stack --resolver lts-16.31 test
+      run: stack --resolver lts-19.6 test

--- a/default.nix
+++ b/default.nix
@@ -31,7 +31,7 @@ rec {
 
   krank_86 = krankBuilder haskell.packages.ghc865Binary;
   krank_88 = krankBuilder haskell.packages.ghc884;
-  krank_810 = krankBuilder (haskell.packages.ghc8104.override {
+  krank_810 = krankBuilder (haskell.packages.ghc8107.override {
     overrides = self: super: with pkgs.haskell.lib; {
       PyF = dontCheck super.PyF;
     };

--- a/krank.cabal
+++ b/krank.cabal
@@ -18,7 +18,7 @@ extra-source-files:  CHANGELOG.md, README.md HACKING.md docs/Checkers/IssueTrack
 common shared-library
   build-depends:       base >= 4.9
                        , PyF >= 0.8.1.0
-                       , aeson >= 1.4.4
+                       , aeson >= 2
                        , bytestring
                        , containers
                        , http-client >= 0.6

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,6 +1,6 @@
 let
-  sha256 = "1f6q98vx3sqxcn6qp5vpy00223r9hy93w9pxq65h9gdwzy3w4qxv";
-  rev = "c6c4a3d45ab2";
+  sha256 = "1f2g3z9xm9h2im2zi246lz8dcd10l1f7qjlg9cri40s7q5x900iq";
+  rev = "375fc4644cb4cb263233bde8b5b4eff1e692359b";
 in
 import (fetchTarball {
   inherit sha256;

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-15.0
+resolver: lts-19.6
 
 packages:
 - .

--- a/tests/Test/Utils/GithubSpec.hs
+++ b/tests/Test/Utils/GithubSpec.hs
@@ -9,7 +9,7 @@ where
 
 import Data.Aeson (Value (..), encode)
 import Data.ByteString.Lazy (ByteString, toStrict)
-import Data.HashMap.Strict (singleton)
+import Data.Aeson.KeyMap (singleton)
 import Data.Text (Text, isInfixOf, isPrefixOf)
 import Network.HTTP.Client (HttpException (..), HttpExceptionContent (..), createCookieJar, defaultRequest)
 import Network.HTTP.Client.Internal (Response (..), ResponseClose (..))

--- a/tests/Test/Utils/GitlabSpec.hs
+++ b/tests/Test/Utils/GitlabSpec.hs
@@ -16,7 +16,7 @@ where
 
 import Data.Aeson (Value (..), encode)
 import Data.ByteString.Lazy (ByteString, toStrict)
-import Data.HashMap.Strict (singleton)
+import Data.Aeson.KeyMap (singleton)
 import Data.Text (Text, isInfixOf, isPrefixOf)
 import Network.HTTP.Client (HttpException (..), HttpExceptionContent (..), createCookieJar, defaultRequest)
 import Network.HTTP.Client.Internal (Response (..), ResponseClose (..))


### PR DESCRIPTION
This is only interesting because krank is currently broken in Nixpkgs,
and this will fix it.  That is also why the PR contains an update of
nixpkgs.nix.